### PR TITLE
Fix for issue 94 Hostname and kubernetes hostnames cannot have uppercase characters

### DIFF
--- a/snaps_k8s/ansible_p/commission/kubernetes/playbooks/deploy_mode/k8/k8_node_label.yaml
+++ b/snaps_k8s/ansible_p/commission/kubernetes/playbooks/deploy_mode/k8/k8_node_label.yaml
@@ -26,13 +26,13 @@
     no_proxy: "{{ no_proxy }}"
   tasks:
      
-    - name: kubectl label nodes {{hostname}} {{label_key}}-
-      command: kubectl --kubeconfig=/etc/kubectl/node-kubeconfig.yaml label nodes {{hostname}} {{label_key}}-
+    - name: kubectl label nodes {{hostname|lower}} {{label_key}}-
+      command: kubectl --kubeconfig=/etc/kubectl/node-kubeconfig.yaml label nodes {{hostname|lower}} {{label_key}}-
       ignore_errors: true
       delegate_to: "localhost" 
 
-    - name: kubectl label nodes {{hostname}} {{label_key}}={{label_value}}
-      command: kubectl --kubeconfig=/etc/kubectl/node-kubeconfig.yaml label nodes {{hostname}} {{label_key}}={{label_value}}
+    - name: kubectl label nodes {{hostname|lower}} {{label_key}}={{label_value}}
+      command: kubectl --kubeconfig=/etc/kubectl/node-kubeconfig.yaml label nodes {{hostname|lower}} {{label_key}}={{label_value}}
       delegate_to: "localhost" 
 
     - name: kubectl get nodes --show-labels


### PR DESCRIPTION
#### What does this PR do?
Fix of issue 94. This patch will convert the uppercase characters to the lowercase character at the time of node labeling.
#### Do you have any concerns with this PR?
No
#### How can the reviewer verify this PR?
By giving hostname value with uppercase characters( like MAster22).
#### Any background context you want to provide?
No
#### Screenshots or logs (if appropriate)
No
#### Questions:
- Have you connected this PR to the issue it resolves?
Yes. #94 
- Does the documentation need an update?
No.
- Does this add new Python dependencies?
No.
- Have you added unit or functional tests for this PR?
No.
- Does this patch update any configuration files?
Yes
