### PR TITLE
Ci ubuntu18 validation

### DIFF
--- a/ci/playbooks/deploy_ha_k8.yaml
+++ b/ci/playbooks/deploy_ha_k8.yaml
@@ -14,6 +14,9 @@
 # limitations under the License.
 ---
 - hosts: all
+
+  gather_facts: no
+
   tasks:
   - name: Install apt dependencies
     become: yes
@@ -37,6 +40,7 @@
       dirs: yes
       rsync_opts:
         - "--exclude=.idea"
+        - "--exclude=venv"
         - "--exclude=.git/objects/pack"
 
   - name: Install requirements-git.txt
@@ -109,7 +113,7 @@
   - name: Apply template and copy deployment.ha.yaml.j2 to {{ deployment_yaml_path }}
     action: template src=templates/deployment.ha.yaml.j2 dest={{ deployment_yaml_path }}
 
-  - name: Deploy K8 - iaas_launch.py -k8_d *** This will run for around ~15 minutes depending on your cloud
+  - name: Deploy K8 - iaas_launch.py -k8_d - see /tmp/k8s_deploy.log for details *** This will run for between 20 and 60 min
     shell: "time python {{ src_copy_dir }}/snaps-kubernetes/iaas_launch.py -f {{ deployment_yaml_path }} -o stdout -k8_d >> /tmp/k8s_deploy.log"
     register: out
     ignore_errors: True

--- a/ci/playbooks/deploy_k8.yaml
+++ b/ci/playbooks/deploy_k8.yaml
@@ -15,6 +15,8 @@
 ---
 - hosts: all
 
+  gather_facts: no
+
   vars:
     inject_keys: "{{ inject_keys }}"
 
@@ -41,6 +43,7 @@
       dirs: yes
       rsync_opts:
         - "--exclude=.idea"
+        - "--exclude=venv"
         - "--exclude=.git/objects/pack"
 
   - name: Install requirements-git.txt
@@ -90,7 +93,7 @@
   - name: Apply template and copy deployment.yaml.j2 to {{ deployment_yaml_path }}
     action: template src=templates/deployment.yaml.j2 dest={{ deployment_yaml_path }}
 
-  - name: Deploy K8 - iaas_launch.py -k8_d *** This will run for around ~15 minutes depending on your cloud
+  - name: Deploy K8 - iaas_launch.py -k8_d - see /tmp/k8s_deploy.log for details *** This will run for between 20 and 60 min
     shell: "time python {{ src_copy_dir }}/snaps-kubernetes/iaas_launch.py -f {{ deployment_yaml_path }} -o stdout -k8_d >> /tmp/k8s_deploy.log"
     register: out
     ignore_errors: True

--- a/ci/playbooks/scripts/validate_deployment.py
+++ b/ci/playbooks/scripts/validate_deployment.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2019 Cable Television Laboratories, Inc. ("CableLabs")
+#                    and others.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+import logging
+import sys
+from snaps_common.file import file_utils
+from snaps_k8s.common.utils import validate_cluster
+
+__author__ = 'spisarski'
+
+logger = logging.getLogger('validate_deployment')
+
+
+def __run(deploy_file):
+    """
+    Validates that the cluster has been properly deployed
+    """
+    k8s_conf = file_utils.read_yaml(deploy_file)
+    validate_cluster.validate_all(k8s_conf)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-d', '--deploy-file', dest='deploy_file',
+                        required=True, help='The k8s config file')
+    args = parser.parse_args()
+
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+    __run(args.deploy_file)

--- a/ci/playbooks/templates/deployment.ha.yaml.j2
+++ b/ci/playbooks/templates/deployment.ha.yaml.j2
@@ -123,8 +123,6 @@ kubernetes:
         storage: 5Gi
   Networks:
   - Default_Network:
-      # TODO/FIXME - Determine why flannel, cilium, & contiv do not work here
-      # weave is working - calico ???
       networking_plugin: {{ networking_plugin }}
       service_subnet:  10.241.241.0/24
       pod_subnet: 10.241.251.0/24
@@ -137,20 +135,19 @@ kubernetes:
 {% if networking_plugin != 'weave' %}
       - weave
 {% endif %}
-#      - flannel
+      - flannel
     - CNI_Configuration:
-      # TODO/FIXME - Flannel is not working
-      #      - Flannel:
-      #        - flannel_network:
-      #            network_name: flannel-network-1
-      #            network: 10.2.0.0/18
-      #            subnet: 24
-      #            isMaster: "false"
-      #        - flannel_network:
-      #            network_name: flannel-network-2
-      #            network: 10.2.1.0/18
-      #            subnet: 24
-      #            isMaster: "false"
+      - Flannel:
+        - flannel_network:
+            network_name: flannel-network-1
+            network: 10.2.0.0/18
+            subnet: 24
+            isMaster: "false"
+        - flannel_network:
+            network_name: flannel-network-2
+            network: 10.2.1.0/18
+            subnet: 24
+            isMaster: "false"
       - Weave:
         - weave_network:
             network_name: weave-network-1

--- a/ci/playbooks/templates/deployment.ha.yaml.j2
+++ b/ci/playbooks/templates/deployment.ha.yaml.j2
@@ -93,6 +93,27 @@ kubernetes:
     no_proxy: "127.0.0.1,localhost,{{ minion_admin_ip_1 }},{{ minion_admin_ip_2 }},{{ master_admin_ip_1 }},{{ master_admin_ip_2 }}"
   Persistent_Volumes:
     Ceph_Volume:
+    - host:
+        hostname: master1
+        ip: {{ master_admin_ip_1 }}
+        user: root
+        password: password
+        node_type: ceph_controller
+        Ceph_claims:
+        - claim_parameters:
+            claim_name: claim1
+            storage: 4Gi
+        - claim_parameters:
+            claim_name: claim2
+            storage: 5Gi
+    - host:
+        hostname: master1
+        ip: {{ master_admin_ip_1 }}
+        user: root
+        password: password
+        node_type: ceph_osd
+        second_storage:
+        - /dev/vdb
     Host_Volume:
     - claim_parameters:
         Claim_name: claim4
@@ -102,27 +123,42 @@ kubernetes:
         storage: 5Gi
   Networks:
   - Default_Network:
-      networking_plugin: weave
+      # TODO/FIXME - Determine why flannel, cilium, & contiv do not work here
+      # weave is working - calico ???
+      networking_plugin: {{ networking_plugin }}
       service_subnet:  10.241.241.0/24
-      pod_subnet: 10.241.241.0/24
+      pod_subnet: 10.241.251.0/24
       network_name: default-network
       isMaster: "true"
   - Multus_network:
     - CNI:
-      - macvlan
-      - flannel
       - dhcp
+      - macvlan
+{% if networking_plugin != 'weave' %}
+      - weave
+{% endif %}
+#      - flannel
     - CNI_Configuration:
-      - Flannel:
-        - flannel_network:
-            network_name: flannel-network-1
-            network: 172.16.0.0/18
-            subnet: 24
-            isMaster: "false"
+      # TODO/FIXME - Flannel is not working
+      #      - Flannel:
+      #        - flannel_network:
+      #            network_name: flannel-network-1
+      #            network: 10.2.0.0/18
+      #            subnet: 24
+      #            isMaster: "false"
+      #        - flannel_network:
+      #            network_name: flannel-network-2
+      #            network: 10.2.1.0/18
+      #            subnet: 24
+      #            isMaster: "false"
       - Weave:
         - weave_network:
             network_name: weave-network-1
-            subnet: 10.80.0.0/24
+            subnet: 10.1.0.0/24
+            isMaster: "false"
+        - weave_network:
+            network_name: weave-network-2
+            subnet: 10.1.2.0/24
             isMaster: "false"
       - Macvlan:
         - macvlan_networks:

--- a/ci/playbooks/templates/deployment.yaml.j2
+++ b/ci/playbooks/templates/deployment.yaml.j2
@@ -59,27 +59,27 @@ kubernetes:
     no_proxy: "127.0.0.1,localhost,{{ minion_admin_ip }},{{ master_admin_ip }}"
   Persistent_Volumes:
     Ceph_Volume:
-#    - host:
-#        hostname: master
-#        ip: {{ master_admin_ip }}
-#        user: root
-#        password: password
-#        node_type: ceph_controller
-#        Ceph_claims:
-#        - claim_parameters:
-#            claim_name: claim1
-#            storage: 4Gi
-#        - claim_parameters:
-#            claim_name: claim2
-#            storage: 5Gi
-#    - host:
-#        hostname: master
-#        ip: {{ master_admin_ip }}
-#        user: root
-#        password: password
-#        node_type: ceph_osd
-#        second_storage:
-#        - /dev/vdb
+    - host:
+        hostname: master
+        ip: {{ master_admin_ip }}
+        user: root
+        password: password
+        node_type: ceph_controller
+        Ceph_claims:
+        - claim_parameters:
+            claim_name: claim1
+            storage: 4Gi
+        - claim_parameters:
+            claim_name: claim2
+            storage: 5Gi
+    - host:
+        hostname: master
+        ip: {{ master_admin_ip }}
+        user: root
+        password: password
+        node_type: ceph_osd
+        second_storage:
+        - /dev/vdb
     Host_Volume:
     - claim_parameters:
         Claim_name: claim4
@@ -89,9 +89,6 @@ kubernetes:
         storage: 5Gi
   Networks:
   - Default_Network:
-      # TODO/FIXME - Determine why flannel, cilium, & contiv do not work here
-      # calico deploys without error but cncf tests ALL fail
-      # weave is working
       networking_plugin: {{ networking_plugin }}
       service_subnet:  10.241.241.0/24
       pod_subnet: 10.241.251.0/24
@@ -100,15 +97,18 @@ kubernetes:
   - Multus_network:
     - CNI:
       - dhcp
+      # TODO/FIXME - Multus is broken with Ubuntu 18
+{% if ubuntu_version == 16 %}
+      # TODO/FIXME - Macvlan is broken with 18.04
       - macvlan
-{% if networking_plugin != 'weave' %}
+{% endif %}
+{% if networking_plugin != 'weave' and ubuntu_version == 16 %}
       - weave
 {% endif %}
-{% if networking_plugin != 'flannel' %}
-      #- flannel
+{% if networking_plugin != 'flannel' and ubuntu_version == 16 %}
+      - flannel
 {% endif %}
     - CNI_Configuration:
-      # TODO/FIXME - Flannel is not working with 1.12.x
       - Flannel:
         - flannel_network:
             network_name: flannel-network-1
@@ -125,12 +125,10 @@ kubernetes:
             network_name: weave-network-1
             subnet: 10.1.0.0/24
             isMaster: "false"
-        # TODO/FIXME - Multiple weave networks does not work
-#        - weave_network:
-#            network_name: weave-network-2
-#            subnet: 10.1.2.0/24
-#            isMaster: "false"
-      # TODO/FIXME - Macvlan appears to be broken with 18.04
+        - weave_network:
+            network_name: weave-network-2
+            subnet: 10.1.2.0/24
+            isMaster: "false"
       - Macvlan:
         - macvlan_networks:
             hostname: minion

--- a/ci/playbooks/templates/deployment.yaml.j2
+++ b/ci/playbooks/templates/deployment.yaml.j2
@@ -24,98 +24,139 @@ kubernetes:
   log_level: debug
   logging_port: "30011"
   basic_authentication:
-    - user:
-        user_name: admin
-        user_password: admin
-        user_id: admin
+  - user:
+      user_name: admin
+      user_password: admin
+      user_id: admin
   node_configuration:
-    - host:
-        hostname: master
-        ip: {{ master_admin_ip }}
-        registry_port: 2376
-        node_type: master
-        label_key: zone
-        label_value: master
-        password: {{ node_host_pass }}
-        user: root
-    - host:
-        hostname: minion
-        ip: {{ minion_admin_ip }}
-        registry_port: 4386
-        node_type: minion
-        label_key: zone
-        label_value: minion
-        password: {{ node_host_pass }}
-        user: root
+  - host:
+      hostname: master
+      ip: {{ master_admin_ip }}
+      registry_port: 2376
+      node_type: master
+      label_key: zone
+      label_value: master
+      password: {{ node_host_pass }}
+      user: root
+  - host:
+      hostname: minion
+      ip: {{ minion_admin_ip }}
+      registry_port: 4386
+      node_type: minion
+      label_key: zone
+      label_value: minion
+      password: {{ node_host_pass }}
+      user: root
   Docker_Repo:
-       ip: {{ master_admin_ip }}
-       port: 4000
-       password: {{ node_host_pass }}
-       user: root
+    ip: {{ master_admin_ip }}
+    port: 4000
+    password: {{ node_host_pass }}
+    user: root
   proxies:
     ftp_proxy: ""
     http_proxy: ""
     https_proxy: ""
     no_proxy: "127.0.0.1,localhost,{{ minion_admin_ip }},{{ master_admin_ip }}"
   Persistent_Volumes:
-      Ceph_Volume:
-      Host_Volume:
-            - claim_parameters:
-                Claim_name: claim4
-                storage: 4Gi
-            - claim_parameters:
-                Claim_name: claim5
-                storage: 5Gi
+    Ceph_Volume:
+#    - host:
+#        hostname: master
+#        ip: {{ master_admin_ip }}
+#        user: root
+#        password: password
+#        node_type: ceph_controller
+#        Ceph_claims:
+#        - claim_parameters:
+#            claim_name: claim1
+#            storage: 4Gi
+#        - claim_parameters:
+#            claim_name: claim2
+#            storage: 5Gi
+#    - host:
+#        hostname: master
+#        ip: {{ master_admin_ip }}
+#        user: root
+#        password: password
+#        node_type: ceph_osd
+#        second_storage:
+#        - /dev/vdb
+    Host_Volume:
+    - claim_parameters:
+        Claim_name: claim4
+        storage: 4Gi
+    - claim_parameters:
+        Claim_name: claim5
+        storage: 5Gi
   Networks:
-      - Default_Network:
-          networking_plugin: weave
-          service_subnet:  10.241.241.0/24
-          pod_subnet: 10.241.241.0/24
-          network_name: default-network
-          isMaster: "true"
-      - Multus_network:
-          - CNI:
-            - macvlan
-            - flannel
-            - dhcp
-          - CNI_Configuration:
-            - Flannel:
-                - flannel_network:
-                    network_name: flannel-network-1
-                    network: 172.16.0.0/18
-                    subnet: 24
-                    isMaster: "false"
-            - Weave:
-                  - weave_network:
-                        network_name: weave-network-1
-                        subnet: 10.80.0.0/24
-                        isMaster: "false"
-            - Macvlan:
-                  - macvlan_networks:
-                        hostname: minion
-                        gateway: 172.16.151.1
-                        ip: 172.16.151.145/24
-                        parent_interface: {{ admin_iface }}
-                        vlanid: 34
-                        master: {{ admin_iface }}.34
-                        network_name: macvlan34-conf-19march
-                        rangeEnd: 172.16.151.60
-                        rangeStart: 172.16.151.55
-                        routes_dst: 0.0.0.0/0
-                        subnet: 172.16.151.0/24
-                        type: host-local
-                        isMaster: "false"
-                  - macvlan_networks:
-                        hostname: minion
-                        gateway: 172.16.151.1
-                        ip: 172.16.151.144/24
-                        parent_interface: {{ admin_iface }}
-                        vlanid: 35
-                        master: {{ admin_iface }}.35
-                        network_name: macvlan35-conf-19march
-                        rangeEnd: 172.16.151.65
-                        rangeStart: 172.16.151.61
-                        routes_dst: 0.0.0.0/0
-                        subnet: 172.16.151.0/24
-                        type: dhcp
-                        isMaster: "false"
+  - Default_Network:
+      # TODO/FIXME - Determine why flannel, cilium, & contiv do not work here
+      # calico deploys without error but cncf tests ALL fail
+      # weave is working
+      networking_plugin: {{ networking_plugin }}
+      service_subnet:  10.241.241.0/24
+      pod_subnet: 10.241.251.0/24
+      network_name: default-network
+      isMaster: "true"
+  - Multus_network:
+    - CNI:
+      - dhcp
+      - macvlan
+{% if networking_plugin != 'weave' %}
+      - weave
+{% endif %}
+{% if networking_plugin != 'flannel' %}
+      #- flannel
+{% endif %}
+    - CNI_Configuration:
+      # TODO/FIXME - Flannel is not working with 1.12.x
+      - Flannel:
+        - flannel_network:
+            network_name: flannel-network-1
+            network: 10.2.0.0/18
+            subnet: 24
+            isMaster: "false"
+        - flannel_network:
+            network_name: flannel-network-2
+            network: 10.2.1.0/18
+            subnet: 24
+            isMaster: "false"
+      - Weave:
+        - weave_network:
+            network_name: weave-network-1
+            subnet: 10.1.0.0/24
+            isMaster: "false"
+        # TODO/FIXME - Multiple weave networks does not work
+#        - weave_network:
+#            network_name: weave-network-2
+#            subnet: 10.1.2.0/24
+#            isMaster: "false"
+      # TODO/FIXME - Macvlan appears to be broken with 18.04
+      - Macvlan:
+        - macvlan_networks:
+            hostname: minion
+            gateway: 172.16.151.1
+            ip: 172.16.151.145/24
+            parent_interface: {{ admin_iface }}
+            vlanid: 34
+            master: {{ admin_iface }}.34
+            network_name: macvlan34-conf-19march
+            rangeEnd: 172.16.151.60
+            rangeStart: 172.16.151.55
+            routes_dst: 0.0.0.0/0
+            subnet: 172.16.151.0/24
+            type: host-local
+            isMaster: "false"
+        - macvlan_networks:
+            hostname: minion
+            gateway: 172.16.151.1
+            ip: 172.16.151.144/24
+            parent_interface: {{ admin_iface }}
+            vlanid: 35
+            master: {{ admin_iface }}.35
+            network_name: macvlan35-conf-19march
+            rangeEnd: 172.16.151.65
+            rangeStart: 172.16.151.61
+            routes_dst: 0.0.0.0/0
+            subnet: 172.16.151.0/24
+            type: dhcp
+            isMaster: "false"

--- a/ci/playbooks/validation.yaml
+++ b/ci/playbooks/validation.yaml
@@ -15,28 +15,12 @@
 ---
 - hosts: all
 
+  gather_facts: no
+
   tasks:
-  - name: Get masters
-    shell: "kubectl --kubeconfig=/tmp/snaps-k8s-projects/{{ project_name }}/node-kubeconfig.yaml get nodes | grep -v 'NAME     STATUS   ROLES    AGE   VERSION' | grep Ready | grep master"
-    register: masters
-
-  - name: Check that expected master count equal {{ num_masters }}
-    fail:
-    when: masters.stdout_lines|length != num_masters
-
-  - name: Get nodes
-    shell: "kubectl --kubeconfig=/tmp/snaps-k8s-projects/{{ project_name }}/node-kubeconfig.yaml get nodes | grep -v 'NAME     STATUS   ROLES    AGE   VERSION' | grep Ready | grep node"
-    register: minions
-
-  - name: Check that expected minion count equal expected {{ num_minions }}
-    fail:
-    when: minions.stdout_lines|length != num_minions
-
-  - name: Get Version
-    shell: "kubectl --kubeconfig=/tmp/snaps-k8s-projects/{{ project_name }}/node-kubeconfig.yaml get nodes | grep -v 'NAME     STATUS   ROLES    AGE   VERSION' | grep Ready | grep {{ k8s_version }}"
-    register: version
-
-  - name: Check number of nodes with the expected version {{ k8s_version }} equals the number of masters and minions
-    fail:
-    when: version.stdout_lines|length != num_masters + num_minions
-
+  - name: python {{ src_copy_dir }}/snaps-kubernetes/ci/playbooks/scripts/validate_deployment.py -d {{ deployment_yaml_path }}
+    command: "python {{ src_copy_dir }}/snaps-kubernetes/ci/playbooks/scripts/validate_deployment.py -d {{ deployment_yaml_path }}"
+    retries: 5
+    delay: 10
+    register: result
+    until: result.rc == 0

--- a/ci/snaps/snaps-env.yaml.tmplt
+++ b/ci/snaps/snaps-env.yaml.tmplt
@@ -1,7 +1,7 @@
 ---
 build_id: {{ build_id }}
 
-k8s_version: {{ k8s_version | default('1.11.0') }}
+k8s_version: {{ k8s_version | default('1.12.4') }}
 
 admin_user: {{ os_admin_user | default('admin') }}
 admin_proj: {{ os_admin_proj | default('admin') }}
@@ -44,3 +44,6 @@ run_validation: {{ run_validation | default(True) }}
 # True will execute the CNCF conformance tests
 run_conformance: {{ run_conformance | default(False) }}
 inject_keys: {{ inject_keys | default(True) }}
+
+# Supported versions 16 & 18
+ubuntu_version: {{ ubuntu_version | default("16") }}

--- a/ci/snaps/snaps_k8_ha_tmplt.yaml
+++ b/ci/snaps/snaps_k8_ha_tmplt.yaml
@@ -83,9 +83,9 @@ openstack:
           project_name: k8-deploy-ha-proj-{{ build_id }}
         name: k8-ctrl-net
         project_name: k8-deploy-ha-proj-{{ build_id }}
-        {% if overlay_mtu is defined %}
+{% if overlay_mtu is defined %}
         mtu: {{ overlay_mtu }}
-        {% endif %}
+{% endif %}
         subnets:
           - subnet:
               name: k8-ctrl-subnet
@@ -98,9 +98,9 @@ openstack:
           project_name: k8-deploy-ha-proj-{{ build_id }}
         name: k8-admin-net
         project_name: k8-deploy-ha-proj-{{ build_id }}
-        {% if overlay_mtu is defined %}
+{% if overlay_mtu is defined %}
         mtu: {{ overlay_mtu }}
-        {% endif %}
+{% endif %}
         subnets:
           - subnet:
               name: k8-admin-subnet

--- a/ci/snaps/snaps_k8_ha_tmplt.yaml
+++ b/ci/snaps/snaps_k8_ha_tmplt.yaml
@@ -52,7 +52,7 @@ openstack:
         vcpus: 4
 {% if flavor_metadata is defined %}
         metadata:
-        {% for key, value in flavor_metadata.iteritems() %}
+        {% for key, value in flavor_metadata.items() %}
           {{ key }}: {{ value }}
         {% endfor %}
 {% endif %}
@@ -64,18 +64,18 @@ openstack:
         vcpus: 4
 {% if flavor_metadata is defined %}
         metadata:
-        {% for key, value in flavor_metadata.iteritems() %}
+        {% for key, value in flavor_metadata.items() %}
           {{ key }}: {{ value }}
         {% endfor %}
 {% endif %}
   images:
     - image:
         os_creds_name: admin-creds
-        name: snaps-ha-image-{{ build_id }}
+        name: snaps-ha-image-u18-{{ build_id }}
         format: qcow2
         public: True
         image_user: ubuntu
-        download_url: https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
+        download_url: https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img
   networks:
     - network:
         os_user:
@@ -112,13 +112,7 @@ openstack:
         os_user:
           name: k8-deploy-ha-user-{{ build_id }}
           project_name: k8-deploy-ha-proj-{{ build_id }}
-        name: minion-vol-1
-        size: 50
-    - volume:
-        os_user:
-          name: k8-deploy-ha-user-{{ build_id }}
-          project_name: k8-deploy-ha-proj-{{ build_id }}
-        name: minion-vol-2
+        name: ceph-vol-1
         size: 50
   routers:
     - router:
@@ -170,14 +164,13 @@ openstack:
             port_range_min: 22
             port_range_max: 22
   instances:
-    # TODO - Improve NIC config. see https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v2.html#network-config-v2
     - instance:
         os_user:
           name: k8-deploy-ha-user-{{ build_id }}
           project_name: k8-deploy-ha-proj-{{ build_id }}
         name: build-k8-vm
         flavor: k8-build-ha-flavor-{{ build_id }}
-        imageName: snaps-ha-image-{{ build_id }}
+        imageName: snaps-ha-image-u18-{{ build_id }}
         keypair_name: k8-deploy-build-kp
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
@@ -199,6 +192,7 @@ openstack:
               name: fip1
               port_name: build-ctrl-port
               router_name: k8-ctrl-router
+        # view in /var/lib/cloud/instance/cloud-config.txt
         userdata: |
           #cloud-config
           packages:
@@ -206,18 +200,20 @@ openstack:
           password: {{ node_host_pass }}
           chpasswd: { expire: False }
           ssh_pwauth: True
-          bootcmd:
-            - [sh, -c, "echo 'auto ens4' > /etc/network/interfaces.d/ens4.cfg"]
-            - [sh, -c, "echo '  iface ens4 inet dhcp' >> /etc/network/interfaces.d/ens4.cfg"]
-            - [sh, -c, "sudo systemctl restart networking"]
+          runcmd:
+            - [sh, -c, "echo '        ens4:' >> /etc/netplan/50-cloud-init.yaml"]
+            - [sh, -c, "echo '            dhcp4: true' >> /etc/netplan/50-cloud-init.yaml"]
+            - sudo netplan apply
     - instance:
         os_user:
           name: k8-deploy-ha-user-{{ build_id }}
           project_name: k8-deploy-ha-proj-{{ build_id }}
         name: k8-master-1
         flavor: k8-node-ha-flavor-{{ build_id }}
-        imageName: snaps-ha-image-{{ build_id }}
+        imageName: snaps-ha-image-u18-{{ build_id }}
         security_group_names: [k8-deploy-build-sg]
+        volume_names:
+        - ceph-vol-1
         cloud_init_timeout: 300
         ports:
           - port:
@@ -226,38 +222,28 @@ openstack:
               ip_addrs:
                 - subnet_name: k8-admin-subnet
                   ip: {{ admin_ip_prfx }}.11
+        # view in /var/lib/cloud/instance/cloud-config.txt
         userdata: |
           #cloud-config
+          packages:
+            - python
           chpasswd:
             list: |
               root:{{ node_host_pass }}
+              ubuntu:{{ node_host_pass }}
             expire: False
           ssh_pwauth: True
-          packages:
-            - python
           runcmd:
-            - [sh, -c, "echo 'auto {{ mult_iface }}' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  iface {{ mult_iface }} inet static' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  address {{ mult_ip_prfx }}.11' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  netmask 255.255.255.0' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  mtu {{ vm_mtu | default('1450') }}'' >> /etc/network/interfaces"]
-            - [sh, -c, "echo 'auto {{ sriov_iface }}' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  iface {{ sriov_iface }} inet static' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  address {{ sriov_ip_prfx }}.11' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  netmask 255.255.255.0' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  mtu {{ vm_mtu | default('1450') }}'' >> /etc/network/interfaces >> /etc/network/interfaces"]
-            - ip addr flush {{ mult_iface }}
-            - systemctl restart networking
-            - apt install -y python
-            - sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
-            - systemctl restart ssh
+            - sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+            - sudo systemctl restart ssh
+            - sudo apt install python
     - instance:
         os_user:
           name: k8-deploy-ha-user-{{ build_id }}
           project_name: k8-deploy-ha-proj-{{ build_id }}
         name: k8-master-2
         flavor: k8-node-ha-flavor-{{ build_id }}
-        imageName: snaps-ha-image-{{ build_id }}
+        imageName: snaps-ha-image-u18-{{ build_id }}
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
         ports:
@@ -267,38 +253,28 @@ openstack:
               ip_addrs:
                 - subnet_name: k8-admin-subnet
                   ip: {{ admin_ip_prfx }}.12
+        # view in /var/lib/cloud/instance/cloud-config.txt
         userdata: |
           #cloud-config
+          packages:
+            - python
           chpasswd:
             list: |
               root:{{ node_host_pass }}
+              ubuntu:{{ node_host_pass }}
             expire: False
           ssh_pwauth: True
-          packages:
-            - python
           runcmd:
-            - [sh, -c, "echo 'auto {{ mult_iface }}' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  iface {{ mult_iface }} inet static' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  address {{ mult_ip_prfx }}.12' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  netmask 255.255.255.0' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  mtu {{ vm_mtu | default('1450') }}'' >> /etc/network/interfaces"]
-            - [sh, -c, "echo 'auto {{ sriov_iface }}' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  iface {{ sriov_iface }} inet static' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  address {{ sriov_ip_prfx }}.12' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  netmask 255.255.255.0' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  mtu {{ vm_mtu | default('1450') }}'' >> /etc/network/interfaces >> /etc/network/interfaces"]
-            - ip addr flush {{ mult_iface }}
-            - systemctl restart networking
-            - apt install -y python
-            - sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
-            - systemctl restart ssh
+            - sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+            - sudo systemctl restart ssh
+            - sudo apt install python
     - instance:
         os_user:
           name: k8-deploy-ha-user-{{ build_id }}
           project_name: k8-deploy-ha-proj-{{ build_id }}
         name: k8-master-3
         flavor: k8-node-ha-flavor-{{ build_id }}
-        imageName: snaps-ha-image-{{ build_id }}
+        imageName: snaps-ha-image-u18-{{ build_id }}
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
         ports:
@@ -310,77 +286,57 @@ openstack:
                   ip: {{ admin_ip_prfx }}.13
         userdata: |
           #cloud-config
+          packages:
+            - python
           chpasswd:
             list: |
               root:{{ node_host_pass }}
+              ubuntu:{{ node_host_pass }}
             expire: False
           ssh_pwauth: True
-          packages:
-            - python
           runcmd:
-            - [sh, -c, "echo 'auto {{ mult_iface }}' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  iface {{ mult_iface }} inet static' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  address {{ mult_ip_prfx }}.13' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  netmask 255.255.255.0' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  mtu {{ vm_mtu | default('1450') }}'' >> /etc/network/interfaces"]
-            - [sh, -c, "echo 'auto {{ sriov_iface }}' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  iface {{ sriov_iface }} inet static' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  address {{ sriov_ip_prfx }}.13' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  netmask 255.255.255.0' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  mtu {{ vm_mtu | default('1450') }}'' >> /etc/network/interfaces >> /etc/network/interfaces"]
-            - ip addr flush {{ mult_iface }}
-            - systemctl restart networking
-            - apt install -y python
-            - sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
-            - systemctl restart ssh
+            - sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+            - sudo systemctl restart ssh
+            - sudo apt install python
     - instance:
         os_user:
           name: k8-deploy-ha-user-{{ build_id }}
           project_name: k8-deploy-ha-proj-{{ build_id }}
         name: k8-minion-1
         flavor: k8-node-ha-flavor-{{ build_id }}
-        imageName: snaps-ha-image-{{ build_id }}
+        imageName: snaps-ha-image-u18-{{ build_id }}
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
-        volume_names:
-          - minion-vol-1
         ports:
-          - port:
-              name: k8-deploy-admin-port-4
-              network_name: k8-admin-net
-              ip_addrs:
-                - subnet_name: k8-admin-subnet
-                  ip: {{ admin_ip_prfx }}.14
+        - port:
+            name: k8-deploy-admin-port-4
+            network_name: k8-admin-net
+            ip_addrs:
+              - subnet_name: k8-admin-subnet
+                ip: {{ admin_ip_prfx }}.14
         userdata: |
           #cloud-config
+          packages:
+            - python
           chpasswd:
             list: |
               root:{{ node_host_pass }}
+              ubuntu:{{ node_host_pass }}
             expire: False
           ssh_pwauth: True
-          packages:
-            - python
           runcmd:
-            - [sh, -c, "echo 'auto {{ admin_iface }}' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  iface {{ admin_iface }} inet static' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  address {{ admin_ip_prfx }}.14' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  netmask 255.255.255.0' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  mtu {{ vm_mtu | default('1450') }}' >> /etc/network/interfaces"]
-            - ip addr flush {{ admin_iface }}
-            - systemctl restart networking
-            - sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
-            - systemctl restart ssh
+            - sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+            - sudo systemctl restart ssh
+            - sudo apt install python
     - instance:
         os_user:
           name: k8-deploy-ha-user-{{ build_id }}
           project_name: k8-deploy-ha-proj-{{ build_id }}
         name: k8-minion-2
         flavor: k8-node-ha-flavor-{{ build_id }}
-        imageName: snaps-ha-image-{{ build_id }}
+        imageName: snaps-ha-image-u18-{{ build_id }}
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
-        volume_names:
-          - minion-vol-2
         ports:
           - port:
               name: k8-deploy-admin-port-5
@@ -390,30 +346,25 @@ openstack:
                   ip: {{ admin_ip_prfx }}.15
         userdata: |
           #cloud-config
+          packages:
+            - python
           chpasswd:
             list: |
               root:{{ node_host_pass }}
+              ubuntu:{{ node_host_pass }}
             expire: False
           ssh_pwauth: True
-          packages:
-            - python
           runcmd:
-            - [sh, -c, "echo 'auto {{ admin_iface }}' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  iface {{ admin_iface }} inet static' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  address {{ admin_ip_prfx }}.15' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  netmask 255.255.255.0' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  mtu {{ vm_mtu | default('1450') }}' >> /etc/network/interfaces"]
-            - ip addr flush {{ admin_iface }}
-            - systemctl restart networking
-            - sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
-            - systemctl restart ssh
+            - sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+            - sudo systemctl restart ssh
+            - sudo apt install python
     - instance:
         os_user:
           name: k8-deploy-ha-user-{{ build_id }}
           project_name: k8-deploy-ha-proj-{{ build_id }}
         name: k8-lb-1
         flavor: k8-node-ha-flavor-{{ build_id }}
-        imageName: snaps-ha-image-{{ build_id }}
+        imageName: snaps-ha-image-u18-{{ build_id }}
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
         ports:
@@ -425,26 +376,21 @@ openstack:
                   ip: {{ admin_ip_prfx }}.16
         userdata: |
           #cloud-config
+          packages:
+            - python
           chpasswd:
             list: |
               root:{{ node_host_pass }}
+              ubuntu:{{ node_host_pass }}
             expire: False
           ssh_pwauth: True
-          packages:
-            - python
           runcmd:
-            - [sh, -c, "echo 'auto {{ admin_iface }}' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  iface {{ admin_iface }} inet static' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  address {{ admin_ip_prfx }}.16' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  netmask 255.255.255.0' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  mtu {{ vm_mtu | default('1450') }}' >> /etc/network/interfaces"]
-            - ip addr flush {{ admin_iface }}
-            - systemctl restart networking
-            - sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
-            - systemctl restart ssh
+            - sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+            - sudo systemctl restart ssh
+            - sudo apt install python
 ansible:
   # Install and configure snaps-boot to build host
-{% if run_build %}
+{% if 'True' == run_build %}
   - playbook_location: {{ local_snaps_k8_dir }}/ci/playbooks/deploy_ha_k8.yaml
     hosts:
     - build-k8-vm
@@ -499,10 +445,26 @@ ansible:
         value: {{ node_host_pass }}
       k8s_version:
         type: string
-        value: {{ k8s_version | default('1.11.0') }}
+        value: {{ k8s_version }}
+      networking_plugin:
+        type: string
+        value: {{ networking_plugin | default('weave') }}
 {% endif %}
 
-{% if run_conformance %}
+{% if 'True' == run_validation %}
+  - playbook_location: {{ local_snaps_k8_dir }}/ci/playbooks/validation.yaml
+    hosts:
+    - build-k8-vm
+    variables:
+      deployment_yaml_path:
+        type: string
+        value: {{ deployment_yaml_target_path }}
+      src_copy_dir:
+        type: string
+        value: {{ src_copy_dir }}
+{% endif %}
+
+{% if 'True' == run_conformance %}
   - playbook_location: {{ local_snaps_k8_dir }}/ci/playbooks/conformance.yaml
     hosts:
     - build-k8-vm

--- a/ci/snaps/snaps_k8_ha_tmplt.yaml
+++ b/ci/snaps/snaps_k8_ha_tmplt.yaml
@@ -71,11 +71,11 @@ openstack:
   images:
     - image:
         os_creds_name: admin-creds
-        name: snaps-ha-image-u18-{{ build_id }}
+        name: snaps-ha-image-{{ build_id }}
         format: qcow2
         public: True
         image_user: ubuntu
-        download_url: https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img
+        download_url: https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
   networks:
     - network:
         os_user:
@@ -170,7 +170,7 @@ openstack:
           project_name: k8-deploy-ha-proj-{{ build_id }}
         name: build-k8-vm
         flavor: k8-build-ha-flavor-{{ build_id }}
-        imageName: snaps-ha-image-u18-{{ build_id }}
+        imageName: snaps-ha-image-{{ build_id }}
         keypair_name: k8-deploy-build-kp
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
@@ -200,17 +200,17 @@ openstack:
           password: {{ node_host_pass }}
           chpasswd: { expire: False }
           ssh_pwauth: True
-          runcmd:
-            - [sh, -c, "echo '        ens4:' >> /etc/netplan/50-cloud-init.yaml"]
-            - [sh, -c, "echo '            dhcp4: true' >> /etc/netplan/50-cloud-init.yaml"]
-            - sudo netplan apply
+          bootcmd:
+            - [sh, -c, "echo 'auto ens4' > /etc/network/interfaces.d/ens4.cfg"]
+            - [sh, -c, "echo '  iface ens4 inet dhcp' >> /etc/network/interfaces.d/ens4.cfg"]
+            - [sh, -c, "sudo systemctl restart networking"]
     - instance:
         os_user:
           name: k8-deploy-ha-user-{{ build_id }}
           project_name: k8-deploy-ha-proj-{{ build_id }}
         name: k8-master-1
         flavor: k8-node-ha-flavor-{{ build_id }}
-        imageName: snaps-ha-image-u18-{{ build_id }}
+        imageName: snaps-ha-image-{{ build_id }}
         security_group_names: [k8-deploy-build-sg]
         volume_names:
         - ceph-vol-1
@@ -234,16 +234,16 @@ openstack:
             expire: False
           ssh_pwauth: True
           runcmd:
-            - sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-            - sudo systemctl restart ssh
-            - sudo apt install python
+          - sudo sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
+          - sudo systemctl restart ssh
+          - sudo apt install -y python
     - instance:
         os_user:
           name: k8-deploy-ha-user-{{ build_id }}
           project_name: k8-deploy-ha-proj-{{ build_id }}
         name: k8-master-2
         flavor: k8-node-ha-flavor-{{ build_id }}
-        imageName: snaps-ha-image-u18-{{ build_id }}
+        imageName: snaps-ha-image-{{ build_id }}
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
         ports:
@@ -265,16 +265,16 @@ openstack:
             expire: False
           ssh_pwauth: True
           runcmd:
-            - sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-            - sudo systemctl restart ssh
-            - sudo apt install python
+          - sudo sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
+          - sudo systemctl restart ssh
+          - sudo apt install -y python
     - instance:
         os_user:
           name: k8-deploy-ha-user-{{ build_id }}
           project_name: k8-deploy-ha-proj-{{ build_id }}
         name: k8-master-3
         flavor: k8-node-ha-flavor-{{ build_id }}
-        imageName: snaps-ha-image-u18-{{ build_id }}
+        imageName: snaps-ha-image-{{ build_id }}
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
         ports:
@@ -295,16 +295,16 @@ openstack:
             expire: False
           ssh_pwauth: True
           runcmd:
-            - sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-            - sudo systemctl restart ssh
-            - sudo apt install python
+          - sudo sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
+          - sudo systemctl restart ssh
+          - sudo apt install -y python
     - instance:
         os_user:
           name: k8-deploy-ha-user-{{ build_id }}
           project_name: k8-deploy-ha-proj-{{ build_id }}
         name: k8-minion-1
         flavor: k8-node-ha-flavor-{{ build_id }}
-        imageName: snaps-ha-image-u18-{{ build_id }}
+        imageName: snaps-ha-image-{{ build_id }}
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
         ports:
@@ -325,16 +325,16 @@ openstack:
             expire: False
           ssh_pwauth: True
           runcmd:
-            - sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-            - sudo systemctl restart ssh
-            - sudo apt install python
+          - sudo sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
+          - sudo systemctl restart ssh
+          - sudo apt install -y python
     - instance:
         os_user:
           name: k8-deploy-ha-user-{{ build_id }}
           project_name: k8-deploy-ha-proj-{{ build_id }}
         name: k8-minion-2
         flavor: k8-node-ha-flavor-{{ build_id }}
-        imageName: snaps-ha-image-u18-{{ build_id }}
+        imageName: snaps-ha-image-{{ build_id }}
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
         ports:
@@ -355,16 +355,16 @@ openstack:
             expire: False
           ssh_pwauth: True
           runcmd:
-            - sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-            - sudo systemctl restart ssh
-            - sudo apt install python
+          - sudo sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
+          - sudo systemctl restart ssh
+          - sudo apt install -y python
     - instance:
         os_user:
           name: k8-deploy-ha-user-{{ build_id }}
           project_name: k8-deploy-ha-proj-{{ build_id }}
         name: k8-lb-1
         flavor: k8-node-ha-flavor-{{ build_id }}
-        imageName: snaps-ha-image-u18-{{ build_id }}
+        imageName: snaps-ha-image-{{ build_id }}
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
         ports:
@@ -385,9 +385,9 @@ openstack:
             expire: False
           ssh_pwauth: True
           runcmd:
-            - sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-            - sudo systemctl restart ssh
-            - sudo apt install python
+          - sudo sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
+          - sudo systemctl restart ssh
+          - sudo apt install -y python
 ansible:
   # Install and configure snaps-boot to build host
 {% if 'True' == run_build %}

--- a/ci/snaps/snaps_k8_tmplt.yaml
+++ b/ci/snaps/snaps_k8_tmplt.yaml
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+{% set ubuntu_version=ubuntu_version or '16' %}
 ---
 openstack:
   connections:
@@ -88,9 +89,9 @@ openstack:
           project_name: k8-deploy-proj-{{ build_id }}
         name: k8-ctrl-net
         project_name: k8-deploy-proj-{{ build_id }}
-        {% if overlay_mtu is defined %}
+{% if overlay_mtu is defined %}
         mtu: {{ overlay_mtu }}
-        {% endif %}
+{% endif %}
         subnets:
           - subnet:
               name: k8-ctrl-subnet
@@ -103,9 +104,9 @@ openstack:
           project_name: k8-deploy-proj-{{ build_id }}
         name: k8-admin-net
         project_name: k8-deploy-proj-{{ build_id }}
-        {% if overlay_mtu is defined %}
+{% if overlay_mtu is defined %}
         mtu: {{ overlay_mtu }}
-        {% endif %}
+{% endif %}
         subnets:
           - subnet:
               name: k8-admin-subnet
@@ -175,11 +176,11 @@ openstack:
           project_name: k8-deploy-proj-{{ build_id }}
         name: build-k8-vm
         flavor: k8-build-flavor-{{ build_id }}
-        {% if ubuntu_version == '18' %}
+{% if ubuntu_version == '18' %}
         imageName: snaps-image-u18-{{ build_id }}
-        {% else %}
+{% else %}
         imageName: snaps-image-{{ build_id }}
-        {% endif %}
+{% endif %}
         keypair_name: k8-deploy-build-kp
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
@@ -210,26 +211,26 @@ openstack:
           chpasswd: { expire: False }
           ssh_pwauth: True
           runcmd:
-          {% if ubuntu_version == '18' %}
+{% if ubuntu_version == '18' %}
           - [sh, -c, "echo '        ens4:' >> /etc/netplan/50-cloud-init.yaml"]
           - [sh, -c, "echo '            dhcp4: true' >> /etc/netplan/50-cloud-init.yaml"]
           - sudo netplan apply
-          {% else %}
+{% else %}
           - [sh, -c, "echo 'auto ens4' > /etc/network/interfaces.d/ens4.cfg"]
           - [sh, -c, "echo '  iface ens4 inet dhcp' >> /etc/network/interfaces.d/ens4.cfg"]
           - [sh, -c, "sudo systemctl restart networking"]
-          {% endif %}
+{% endif %}
     - instance:
         os_user:
           name: k8-deploy-user-{{ build_id }}
           project_name: k8-deploy-proj-{{ build_id }}
         name: k8-master
         flavor: k8-node-flavor-{{ build_id }}
-        {% if ubuntu_version == '18' %}
+{% if ubuntu_version == '18' %}
         imageName: snaps-image-u18-{{ build_id }}
-        {% else %}
+{% else %}
         imageName: snaps-image-{{ build_id }}
-        {% endif %}
+{% endif %}
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
         volume_names:
@@ -253,11 +254,11 @@ openstack:
             expire: False
           ssh_pwauth: True
           runcmd:
-            {% if ubuntu_version == '18' %}
+{% if ubuntu_version == '18' %}
             - sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-            {% else %}
+{% else %}
             - sudo sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
-            {% endif %}
+{% endif %}
             - sudo systemctl restart ssh
             - sudo apt install -y python
     - instance:
@@ -266,11 +267,11 @@ openstack:
           project_name: k8-deploy-proj-{{ build_id }}
         name: k8-minion
         flavor: k8-node-flavor-{{ build_id }}
-        {% if ubuntu_version == '18' %}
+{% if ubuntu_version == '18' %}
         imageName: snaps-image-u18-{{ build_id }}
-        {% else %}
+{% else %}
         imageName: snaps-image-{{ build_id }}
-        {% endif %}
+{% endif %}
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
         ports:
@@ -291,11 +292,11 @@ openstack:
             expire: False
           ssh_pwauth: True
           runcmd:
-            {% if ubuntu_version == '18' %}
+{% if ubuntu_version == '18' %}
             - sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-            {% else %}
+{% else %}
             - sudo sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
-            {% endif %}
+{% endif %}
             - sudo systemctl restart ssh
             - sudo apt install -y python
 ansible:

--- a/ci/snaps/snaps_k8_tmplt.yaml
+++ b/ci/snaps/snaps_k8_tmplt.yaml
@@ -175,11 +175,11 @@ openstack:
           project_name: k8-deploy-proj-{{ build_id }}
         name: build-k8-vm
         flavor: k8-build-flavor-{{ build_id }}
-{% if ubuntu_version == '18' %}
+        {% if ubuntu_version == '18' %}
         imageName: snaps-image-u18-{{ build_id }}
-{% else %}
+        {% else %}
         imageName: snaps-image-{{ build_id }}
-{% endif %}
+        {% endif %}
         keypair_name: k8-deploy-build-kp
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
@@ -210,26 +210,26 @@ openstack:
           chpasswd: { expire: False }
           ssh_pwauth: True
           runcmd:
-{% if ubuntu_version == '18' %}
+          {% if ubuntu_version == '18' %}
           - [sh, -c, "echo '        ens4:' >> /etc/netplan/50-cloud-init.yaml"]
           - [sh, -c, "echo '            dhcp4: true' >> /etc/netplan/50-cloud-init.yaml"]
           - sudo netplan apply
-{% else %}
+          {% else %}
           - [sh, -c, "echo 'auto ens4' > /etc/network/interfaces.d/ens4.cfg"]
           - [sh, -c, "echo '  iface ens4 inet dhcp' >> /etc/network/interfaces.d/ens4.cfg"]
           - [sh, -c, "sudo systemctl restart networking"]
-{% endif %}
+          {% endif %}
     - instance:
         os_user:
           name: k8-deploy-user-{{ build_id }}
           project_name: k8-deploy-proj-{{ build_id }}
         name: k8-master
         flavor: k8-node-flavor-{{ build_id }}
-{% if ubuntu_version == '18' %}
+        {% if ubuntu_version == '18' %}
         imageName: snaps-image-u18-{{ build_id }}
-{% else %}
+        {% else %}
         imageName: snaps-image-{{ build_id }}
-{% endif %}
+        {% endif %}
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
         volume_names:
@@ -253,11 +253,11 @@ openstack:
             expire: False
           ssh_pwauth: True
           runcmd:
-{% if ubuntu_version == '18' %}
+            {% if ubuntu_version == '18' %}
             - sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-{% else %}
+            {% else %}
             - sudo sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
-{% endif %}
+            {% endif %}
             - sudo systemctl restart ssh
             - sudo apt install -y python
     - instance:
@@ -266,11 +266,11 @@ openstack:
           project_name: k8-deploy-proj-{{ build_id }}
         name: k8-minion
         flavor: k8-node-flavor-{{ build_id }}
-{% if ubuntu_version == '18' %}
+        {% if ubuntu_version == '18' %}
         imageName: snaps-image-u18-{{ build_id }}
-{% else %}
+        {% else %}
         imageName: snaps-image-{{ build_id }}
-{% endif %}
+        {% endif %}
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
         ports:
@@ -291,11 +291,11 @@ openstack:
             expire: False
           ssh_pwauth: True
           runcmd:
-{% if ubuntu_version == '18' %}
+            {% if ubuntu_version == '18' %}
             - sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-{% else %}
+            {% else %}
             - sudo sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
-{% endif %}
+            {% endif %}
             - sudo systemctl restart ssh
             - sudo apt install -y python
 ansible:
@@ -341,6 +341,9 @@ ansible:
       k8s_version:
         type: string
         value: {{ k8s_version }}
+      ubuntu_version:
+        type: string
+        value: {{ ubuntu_version }}
       networking_plugin:
         type: string
         value: {{ networking_plugin | default('weave') }}

--- a/ci/snaps/snaps_k8_tmplt.yaml
+++ b/ci/snaps/snaps_k8_tmplt.yaml
@@ -52,33 +52,35 @@ openstack:
         vcpus: {{ build_cpus | default(1) }}
 {% if flavor_metadata is defined %}
         metadata:
-        {% for key, value in flavor_metadata.iteritems() %}
+        {% for key, value in flavor_metadata.items() %}
           {{ key }}: {{ value }}
         {% endfor %}
 {% endif %}
     - flavor:
         os_creds_name: admin-creds
         name: k8-node-flavor-{{ build_id }}
-        ram: 16384
-        disk: 80
-        vcpus: 4
-        ram: {{ build_ram | default(8192) }}
-        disk: {{ build_disk | default(50) }}
-        vcpus: {{ build_cpus | default(2) }}
+        ram: {{ node_ram | default(8192) }}
+        disk: {{ node_disk | default(50) }}
+        vcpus: {{ node_cpus | default(2) }}
 {% if flavor_metadata is defined %}
         metadata:
-        {% for key, value in flavor_metadata.iteritems() %}
+        {% for key, value in flavor_metadata.items() %}
           {{ key }}: {{ value }}
         {% endfor %}
 {% endif %}
   images:
     - image:
         os_creds_name: admin-creds
+{% if ubuntu_version == '18' %}
+        name: snaps-image-u18-{{ build_id }}
+        download_url: https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img
+{% else %}
         name: snaps-image-{{ build_id }}
+        download_url: https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
+{% endif %}
         format: qcow2
         public: True
         image_user: ubuntu
-        download_url: https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
   networks:
     - network:
         os_user:
@@ -115,7 +117,7 @@ openstack:
         os_user:
           name: k8-deploy-user-{{ build_id }}
           project_name: k8-deploy-proj-{{ build_id }}
-        name: minion-vol
+        name: ceph-vol
         size: 50
   routers:
     - router:
@@ -167,14 +169,17 @@ openstack:
             port_range_min: 22
             port_range_max: 22
   instances:
-    # TODO - Improve NIC config. see https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v2.html#network-config-v2
     - instance:
         os_user:
           name: k8-deploy-user-{{ build_id }}
           project_name: k8-deploy-proj-{{ build_id }}
         name: build-k8-vm
         flavor: k8-build-flavor-{{ build_id }}
+{% if ubuntu_version == '18' %}
+        imageName: snaps-image-u18-{{ build_id }}
+{% else %}
         imageName: snaps-image-{{ build_id }}
+{% endif %}
         keypair_name: k8-deploy-build-kp
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
@@ -196,6 +201,7 @@ openstack:
               name: fip1
               port_name: build-ctrl-port
               router_name: k8-ctrl-router
+        # view in /var/lib/cloud/instance/cloud-config.txt
         userdata: |
           #cloud-config
           packages:
@@ -203,19 +209,31 @@ openstack:
           password: {{ node_host_pass }}
           chpasswd: { expire: False }
           ssh_pwauth: True
-          bootcmd:
-            - [sh, -c, "echo 'auto ens4' > /etc/network/interfaces.d/ens4.cfg"]
-            - [sh, -c, "echo '  iface ens4 inet dhcp' >> /etc/network/interfaces.d/ens4.cfg"]
-            - [sh, -c, "sudo systemctl restart networking"]
+          runcmd:
+{% if ubuntu_version == '18' %}
+          - [sh, -c, "echo '        ens4:' >> /etc/netplan/50-cloud-init.yaml"]
+          - [sh, -c, "echo '            dhcp4: true' >> /etc/netplan/50-cloud-init.yaml"]
+          - sudo netplan apply
+{% else %}
+          - [sh, -c, "echo 'auto ens4' > /etc/network/interfaces.d/ens4.cfg"]
+          - [sh, -c, "echo '  iface ens4 inet dhcp' >> /etc/network/interfaces.d/ens4.cfg"]
+          - [sh, -c, "sudo systemctl restart networking"]
+{% endif %}
     - instance:
         os_user:
           name: k8-deploy-user-{{ build_id }}
           project_name: k8-deploy-proj-{{ build_id }}
         name: k8-master
         flavor: k8-node-flavor-{{ build_id }}
+{% if ubuntu_version == '18' %}
+        imageName: snaps-image-u18-{{ build_id }}
+{% else %}
         imageName: snaps-image-{{ build_id }}
+{% endif %}
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
+        volume_names:
+          - ceph-vol
         ports:
           - port:
               name: k8-deploy-admin-port-1
@@ -223,42 +241,38 @@ openstack:
               ip_addrs:
                 - subnet_name: k8-admin-subnet
                   ip: {{ admin_ip_prfx }}.11
+        # view in /var/lib/cloud/instance/cloud-config.txt
         userdata: |
           #cloud-config
+          packages:
+            - python
           chpasswd:
             list: |
               root:{{ node_host_pass }}
+              ubuntu:{{ node_host_pass }}
             expire: False
           ssh_pwauth: True
-          packages:
-            - python
           runcmd:
-            - [sh, -c, "echo 'auto {{ mult_iface }}' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  iface {{ mult_iface }} inet static' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  address {{ mult_ip_prfx }}.11' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  netmask 255.255.255.0' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  mtu {{ vm_mtu | default('1450') }}'' >> /etc/network/interfaces"]
-            - [sh, -c, "echo 'auto {{ sriov_iface }}' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  iface {{ sriov_iface }} inet static' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  address {{ sriov_ip_prfx }}.11' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  netmask 255.255.255.0' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  mtu {{ vm_mtu | default('1450') }}'' >> /etc/network/interfaces >> /etc/network/interfaces"]
-            - ip addr flush {{ mult_iface }}
-            - systemctl restart networking
-            - apt install -y python
-            - sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
-            - systemctl restart ssh
+{% if ubuntu_version == '18' %}
+            - sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+{% else %}
+            - sudo sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
+{% endif %}
+            - sudo systemctl restart ssh
+            - sudo apt install -y python
     - instance:
         os_user:
           name: k8-deploy-user-{{ build_id }}
           project_name: k8-deploy-proj-{{ build_id }}
         name: k8-minion
         flavor: k8-node-flavor-{{ build_id }}
+{% if ubuntu_version == '18' %}
+        imageName: snaps-image-u18-{{ build_id }}
+{% else %}
         imageName: snaps-image-{{ build_id }}
+{% endif %}
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
-        volume_names:
-          - minion-vol
         ports:
           - port:
               name: k8-deploy-admin-port-2
@@ -268,27 +282,28 @@ openstack:
                   ip: {{ admin_ip_prfx }}.12
         userdata: |
           #cloud-config
+          packages:
+            - python
           chpasswd:
             list: |
               root:{{ node_host_pass }}
+              ubuntu:{{ node_host_pass }}
             expire: False
           ssh_pwauth: True
-          packages:
-            - python
           runcmd:
-            - [sh, -c, "echo 'auto {{ admin_iface }}' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  iface {{ admin_iface }} inet static' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  address {{ admin_ip_prfx }}.12' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  netmask 255.255.255.0' >> /etc/network/interfaces"]
-            - [sh, -c, "echo '  mtu {{ vm_mtu | default('1450') }}' >> /etc/network/interfaces"]
-            - ip addr flush {{ admin_iface }}
-            - systemctl restart networking
-            - sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
-            - systemctl restart ssh
+{% if ubuntu_version == '18' %}
+            - sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+{% else %}
+            - sudo sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
+{% endif %}
+            - sudo systemctl restart ssh
+            - sudo apt install -y python
 ansible:
   # Install and configure snaps-boot to build host
-{% if run_build | default(True) %}
+{% if 'True' == run_build %}
   - playbook_location: {{ local_snaps_k8_dir }}/ci/playbooks/deploy_k8.yaml
+    post_processing:
+      sleep: 15
     hosts:
     - build-k8-vm
     variables:
@@ -325,29 +340,26 @@ ansible:
         value: {{ inject_keys | default(True) }}
       k8s_version:
         type: string
-        value: {{ k8s_version | default('1.11.0') }}
+        value: {{ k8s_version }}
+      networking_plugin:
+        type: string
+        value: {{ networking_plugin | default('weave') }}
 {% endif %}
 
-{% if run_validation | default(True) %}
+{% if 'True' == run_validation %}
   - playbook_location: {{ local_snaps_k8_dir }}/ci/playbooks/validation.yaml
     hosts:
     - build-k8-vm
     variables:
-      project_name:
+      deployment_yaml_path:
         type: string
-        value: {{ build_id }}
-      k8s_version:
+        value: {{ deployment_yaml_target_path }}
+      src_copy_dir:
         type: string
-        value: {{ k8s_version | default('1.11.0') }}
-      num_masters:
-        type: string
-        value: 1
-      num_minions:
-        type: string
-        value: 1
+        value: {{ src_copy_dir }}
 {% endif %}
 
-{% if run_conformance | default(False) %}
+{% if 'True' == run_conformance %}
   - playbook_location: {{ local_snaps_k8_dir }}/ci/playbooks/conformance.yaml
     hosts:
     - build-k8-vm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 mock
+kubernetes
 netaddr
 PyYaml
-ansible==2.7
+ansible==2.7.0

--- a/snaps_k8s/common/utils/config_utils.py
+++ b/snaps_k8s/common/utils/config_utils.py
@@ -172,7 +172,7 @@ def get_default_network(k8s_conf):
     networks = get_networks(k8s_conf)
     for network in networks:
         if consts.DFLT_NET_KEY in network:
-                return network[consts.DFLT_NET_KEY]
+            return network[consts.DFLT_NET_KEY]
 
 
 def get_service_subnet(k8s_conf):

--- a/snaps_k8s/common/utils/config_utils.py
+++ b/snaps_k8s/common/utils/config_utils.py
@@ -396,6 +396,22 @@ def get_ceph_vol(k8s_conf):
     return persist_vol.get(consts.CEPH_VOLUME_KEY)
 
 
+def get_ceph_claims(k8s_conf):
+    """
+    Returns the Ceph Volume settings
+    :param k8s_conf: the configuration dict
+    :return: a list
+    """
+    out_claims = list()
+    ceph_hosts = get_ceph_hosts(k8s_conf)
+    for ceph_host in ceph_hosts:
+        if consts.CEPH_CLAIMS_KEY in ceph_host:
+            claims = ceph_host[consts.CEPH_CLAIMS_KEY]
+            for claim in claims:
+                out_claims.append(claim[consts.CLAIM_PARAMS_KEY])
+    return out_claims
+
+
 def get_ceph_hosts(k8s_conf):
     """
     Returns the Ceph control host settings

--- a/snaps_k8s/common/utils/validate_cluster.py
+++ b/snaps_k8s/common/utils/validate_cluster.py
@@ -1,0 +1,244 @@
+# Copyright (c) 2019 Cable Television Laboratories, Inc. ("CableLabs")
+#                    and others.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from kubernetes import client, config
+from snaps_k8s.common.consts import consts
+from snaps_k8s.common.utils import config_utils
+
+__author__ = 'spisarski'
+
+logger = logging.getLogger('validate_cluster')
+
+
+def k8s_client(k8s_conf):
+    """
+    Retrieves the kubernetes client
+    :param k8s_conf: the k8s configuration used to deploy the cluster
+    :return:
+    """
+    config.load_kube_config("{}/node-kubeconfig.yaml".format(
+        config_utils.get_project_artifact_dir(k8s_conf)))
+    return client.CoreV1Api()
+
+
+def validate_all(k8s_conf):
+    """
+    Uses ansible_utils for applying Ansible Playbooks to machines with a
+    private key
+    :param k8s_conf: the k8s configuration used to deploy the cluster
+    """
+    config.load_kube_config("{}/node-kubeconfig.yaml".format(
+        config_utils.get_project_artifact_dir(k8s_conf)))
+    cluster_client = k8s_client(k8s_conf)
+
+    logger.info('Starting K8S Validation')
+    validate_nodes(k8s_conf, cluster_client)
+    validate_k8s_system(k8s_conf, cluster_client)
+    validate_cni(k8s_conf, cluster_client)
+    validate_volumes(k8s_conf, cluster_client)
+
+
+def validate_nodes(k8s_conf, cluster_client):
+    """
+    Validation of the configured kubernetes nodes
+    :param k8s_conf: the k8s configuration used to deploy the cluster
+    :param cluster_client: the k8s API client
+    :raises Exception
+    """
+    logger.info('Validate K8 Nodes')
+
+    node_list = cluster_client.list_node()
+    node_items = node_list.items
+
+    masters_tuple3 = config_utils.get_master_nodes_ip_name_type(k8s_conf)
+    master_names = list()
+    for name, ip, node_type in masters_tuple3:
+        master_names.append(name)
+
+    minions_tuple3 = config_utils.get_minion_nodes_ip_name_type(k8s_conf)
+    minion_names = list()
+    for name, ip, node_type in minions_tuple3:
+        minion_names.append(name)
+
+    master_count = 0
+    minion_count = 0
+    for node_item in node_items:
+        node_meta = node_item.metadata
+        node_status = node_item.status
+        node_conditions = node_status.conditions
+        kubelet_reason = False
+        for node_condition in node_conditions:
+            if node_condition.reason == 'KubeletReady':
+                assert node_condition.status == 'True'
+                assert node_condition.type == 'Ready'
+                kubelet_reason = True
+        assert kubelet_reason
+
+        node_info = node_status.node_info
+        node_kubelet_version = node_info.kubelet_version
+        expected_version = config_utils.get_version(k8s_conf)
+        assert node_kubelet_version == expected_version
+        logger.debug('Expected version [%s] == actual [%s]',
+                     expected_version, node_kubelet_version)
+
+        node_name = node_meta.name
+        node_labels = node_meta.labels
+        if node_labels.get('node-role.kubernetes.io/master') is not None:
+            assert node_name in master_names
+            master_count += 1
+            logger.debug('Master found with name [%s]', node_name)
+
+        if node_labels.get('node-role.kubernetes.io/node') is not None:
+            assert node_name in minion_names
+            minion_count += 1
+            logger.debug('Minion found with name [%s]', node_name)
+
+    assert master_count == len(masters_tuple3)
+    logger.info('Number of masters [%s]', master_count)
+    assert minion_count == len(minions_tuple3)
+    logger.info('Number of minions [%s]', minion_count)
+
+
+def validate_k8s_system(k8s_conf, cluster_client):
+    """
+    Validation of the configured kubernetes system
+    :param k8s_conf: the k8s configuration used to deploy the cluster
+    :param cluster_client: the k8s API client
+    :raises Exception
+    """
+    logger.info('Validate K8s System')
+
+    pod_items = __get_pods_by_namespace(cluster_client, 'kube-system')
+
+    pod_status = __get_pod_name_statuses(pod_items)
+    for pod_name, pod_running in pod_status.items():
+        if not pod_running:
+            logger.warn('Pod %s is not running', pod_name)
+        assert pod_running
+
+    pod_services = __get_pod_service_list(pod_items)
+    logger.debug('pod_services - %s', pod_services)
+    assert 'dns-autoscaler' in pod_services
+    assert 'kube-proxy' in pod_services
+    assert 'kubernetes-dashboard' in pod_services
+    assert 'coredns' in pod_services
+    assert 'efk' in pod_services
+
+    for name, ip, node_type in config_utils.get_master_nodes_ip_name_type(
+            k8s_conf):
+        assert 'kube-apiserver-{}'.format(name) in pod_services
+        assert 'kube-scheduler-{}'.format(name) in pod_services
+
+    if config_utils.is_metrics_server_enabled(k8s_conf):
+        assert 'metrics-server' in pod_services
+    else:
+        assert 'metrics-server' not in pod_services
+
+
+def validate_cni(k8s_conf, cluster_client):
+    """
+    Validation of the configured kubernetes CNIs and network elements
+    :param k8s_conf: the k8s configuration used to deploy the cluster
+    :param cluster_client: the k8s API client
+    :raises Exception
+    """
+    logger.info('Validate K8s CNIs')
+
+    pod_items = __get_pods_by_namespace(cluster_client, 'kube-system')
+    pod_services = __get_pod_service_list(pod_items)
+    logger.info('pod_services - %s', pod_services)
+    net_plugin = config_utils.get_networking_plugin(k8s_conf)
+    if net_plugin == consts.WEAVE_TYPE:
+        assert 'weave-net' in pod_services
+    elif net_plugin == consts.FLANNEL_TYPE:
+        assert 'flannel' in pod_services
+    elif net_plugin == 'contiv':
+        assert 'contiv-netplugin' in pod_services
+    elif net_plugin == 'calico':
+        assert 'calico-net' in pod_services
+    elif net_plugin == 'cilium':
+        assert 'cilium-net' in pod_services
+
+
+def validate_volumes(k8s_conf, cluster_client):
+    """
+    Validation of the configured kubernetes volumes
+    :param k8s_conf: the k8s configuration used to deploy the cluster
+    :param cluster_client: the k8s API client
+    :raises Exception
+    """
+    logger.info('Validate K8s Volumes')
+    pvol_list = cluster_client.list_persistent_volume()
+    for pvol in pvol_list.items:
+        logger.info('pvol - \n%s', pvol)
+
+    pv_claims = config_utils.get_persist_vol_claims(k8s_conf)
+    ceph_claims = config_utils.get_ceph_claims(k8s_conf)
+    claims = cluster_client.list_persistent_volume_claim_for_all_namespaces()
+    for claim in claims.items:
+        logger.info('claim - \n%s', claim)
+    pass
+
+
+def __get_pods_by_namespace(cluster_client, namespace):
+    """
+    Retrieves the pods for a given namespace
+    :param cluster_client: the kubernetes API client
+    :param namespace: the namespace of the pod to add into the return list
+    :return: list of pod item objects
+    """
+    out_pods = list()
+
+    pod_list = cluster_client.list_pod_for_all_namespaces()
+    pod_items = pod_list.items
+
+    for pod_item in pod_items:
+        pod_meta = pod_item.metadata
+        if pod_meta.namespace == namespace:
+            out_pods.append(pod_item)
+
+    return out_pods
+
+
+def __get_pod_name_statuses(pod_items):
+    """
+    Returns a dict where the key is the name of a pod and the value is a flag
+    where False indicates that the container is in a waiting state
+    :param pod_items: the list of pod_items from which to extract the name
+    :return: dict of pod names/status codes
+    """
+    out_dict = dict()
+    for pod_item in pod_items:
+        cont_stat = pod_item.status.container_statuses[0]
+        out_dict[pod_item.metadata.name] = cont_stat.state.waiting is None
+        if cont_stat.state.waiting is not None:
+            logger.warn('pod_item.status.container_statuses - \n%s',
+                        pod_item.status.container_statuses)
+    return out_dict
+
+
+def __get_pod_service_list(pod_items):
+    """
+    Returns a set of pod service_account names from the pod_list parameter
+    :param pod_items: the list of pod_items from which to extract the name
+    :return: set of pod names
+    """
+    out_names = set()
+    for pod_item in pod_items:
+        if pod_item.spec.service_account:
+            out_names.add(pod_item.spec.service_account)
+        else:
+            out_names.add(pod_item.metadata.name)
+    return out_names

--- a/snaps_k8s/common/utils/validate_cluster.py
+++ b/snaps_k8s/common/utils/validate_cluster.py
@@ -129,11 +129,9 @@ def validate_k8s_system(k8s_conf, cluster_client):
         assert pod_running
 
     pod_services = __get_pod_service_list(pod_items)
-    logger.debug('pod_services - %s', pod_services)
-    assert 'dns-autoscaler' in pod_services
-    assert 'kube-proxy' in pod_services
+    logger.info('pod_services - %s', pod_services)
     assert 'kubernetes-dashboard' in pod_services
-    assert 'coredns' in pod_services
+    assert 'kube-dns' in pod_services
     assert 'efk' in pod_services
 
     for name, ip, node_type in config_utils.get_master_nodes_ip_name_type(

--- a/snaps_k8s/common/utils/validate_cluster.py
+++ b/snaps_k8s/common/utils/validate_cluster.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import logging
 from kubernetes import client, config
+from kubernetes.client import apis
 from snaps_k8s.common.consts import consts
 from snaps_k8s.common.utils import config_utils
 
@@ -22,7 +23,7 @@ __author__ = 'spisarski'
 logger = logging.getLogger('validate_cluster')
 
 
-def k8s_client(k8s_conf):
+def k8s_core_client(k8s_conf):
     """
     Retrieves the kubernetes client
     :param k8s_conf: the k8s configuration used to deploy the cluster
@@ -33,6 +34,17 @@ def k8s_client(k8s_conf):
     return client.CoreV1Api()
 
 
+def k8s_net_client(k8s_conf):
+    """
+    Retrieves the kubernetes networking client
+    :param k8s_conf: the k8s configuration used to deploy the cluster
+    :return:
+    """
+    config.load_kube_config("{}/node-kubeconfig.yaml".format(
+        config_utils.get_project_artifact_dir(k8s_conf)))
+    return client.NetworkingV1Api()
+
+
 def validate_all(k8s_conf):
     """
     Uses ansible_utils for applying Ansible Playbooks to machines with a
@@ -41,25 +53,25 @@ def validate_all(k8s_conf):
     """
     config.load_kube_config("{}/node-kubeconfig.yaml".format(
         config_utils.get_project_artifact_dir(k8s_conf)))
-    cluster_client = k8s_client(k8s_conf)
+    core_client = k8s_core_client(k8s_conf)
 
     logger.info('Starting K8S Validation')
-    validate_nodes(k8s_conf, cluster_client)
-    validate_k8s_system(k8s_conf, cluster_client)
-    validate_cni(k8s_conf, cluster_client)
-    validate_volumes(k8s_conf, cluster_client)
+    validate_nodes(k8s_conf, core_client)
+    validate_k8s_system(k8s_conf, core_client)
+    validate_cni(k8s_conf, core_client)
+    validate_volumes(k8s_conf, core_client)
 
 
-def validate_nodes(k8s_conf, cluster_client):
+def validate_nodes(k8s_conf, core_client):
     """
     Validation of the configured kubernetes nodes
     :param k8s_conf: the k8s configuration used to deploy the cluster
-    :param cluster_client: the k8s API client
+    :param core_client: the k8s core API client
     :raises Exception
     """
     logger.info('Validate K8 Nodes')
 
-    node_list = cluster_client.list_node()
+    node_list = core_client.list_node()
     node_items = node_list.items
 
     masters_tuple3 = config_utils.get_master_nodes_ip_name_type(k8s_conf)
@@ -111,16 +123,16 @@ def validate_nodes(k8s_conf, cluster_client):
     logger.info('Number of minions [%s]', minion_count)
 
 
-def validate_k8s_system(k8s_conf, cluster_client):
+def validate_k8s_system(k8s_conf, core_client):
     """
     Validation of the configured kubernetes system
     :param k8s_conf: the k8s configuration used to deploy the cluster
-    :param cluster_client: the k8s API client
+    :param core_client: the k8s core API client
     :raises Exception
     """
     logger.info('Validate K8s System')
 
-    pod_items = __get_pods_by_namespace(cluster_client, 'kube-system')
+    pod_items = __get_pods_by_namespace(core_client, 'kube-system')
 
     pod_status = __get_pod_name_statuses(pod_items)
     for pod_name, pod_running in pod_status.items():
@@ -129,7 +141,7 @@ def validate_k8s_system(k8s_conf, cluster_client):
         assert pod_running
 
     pod_services = __get_pod_service_list(pod_items)
-    logger.info('pod_services - %s', pod_services)
+    logger.debug('pod_services - %s', pod_services)
     assert 'kubernetes-dashboard' in pod_services
     assert 'kube-dns' in pod_services
     assert 'efk' in pod_services
@@ -145,18 +157,30 @@ def validate_k8s_system(k8s_conf, cluster_client):
         assert 'metrics-server' not in pod_services
 
 
-def validate_cni(k8s_conf, cluster_client):
+def validate_cni(k8s_conf, core_client):
     """
     Validation of the configured kubernetes CNIs and network elements
     :param k8s_conf: the k8s configuration used to deploy the cluster
-    :param cluster_client: the k8s API client
+    :param core_client: the k8s core API client
     :raises Exception
     """
     logger.info('Validate K8s CNIs')
+    __validate_cni_pods(k8s_conf, core_client)
+    __validate_cni_networks(k8s_conf)
 
-    pod_items = __get_pods_by_namespace(cluster_client, 'kube-system')
+
+def __validate_cni_pods(k8s_conf, core_client):
+    """
+    Validates that the expected CNI pods are running
+    :param k8s_conf: the k8s configuration used to deploy the cluster
+    :param core_client: the k8s core API client
+    :raises Exception
+    """
+    logger.info('Validate K8s CNI Pods')
+
+    pod_items = __get_pods_by_namespace(core_client, 'kube-system')
     pod_services = __get_pod_service_list(pod_items)
-    logger.info('pod_services - %s', pod_services)
+    logger.debug('pod_services - %s', pod_services)
     net_plugin = config_utils.get_networking_plugin(k8s_conf)
     if net_plugin == consts.WEAVE_TYPE:
         assert 'weave-net' in pod_services
@@ -170,36 +194,105 @@ def validate_cni(k8s_conf, cluster_client):
         assert 'cilium-net' in pod_services
 
 
-def validate_volumes(k8s_conf, cluster_client):
+def __validate_cni_networks(k8s_conf):
+    """
+    Validates that the expected CNI networks have been deployed
+    :param k8s_conf: the k8s configuration used to deploy the cluster
+    :param core_client: the k8s core API client
+    :raises Exception
+    """
+    logger.info('Validate K8s CNI Networks')
+    net_client = k8s_net_client(k8s_conf)
+    net_policies = net_client.list_network_policy_for_all_namespaces()
+    logger.info('net_policies - %s', net_policies)
+
+    ext_client = apis.ExtensionsV1beta1Api()
+    net_policies2 = ext_client.list_network_policy_for_all_namespaces()
+    logger.info('net_policies2 - %s', net_policies2)
+
+    custom_obj_client = apis.CustomObjectsApi()
+    networks = custom_obj_client.list_cluster_custom_object('network', 'v1', 'network')
+    logger.info('networks - %s', networks)
+
+
+def validate_volumes(k8s_conf, core_client):
     """
     Validation of the configured kubernetes volumes
     :param k8s_conf: the k8s configuration used to deploy the cluster
-    :param cluster_client: the k8s API client
+    :param core_client: the k8s core API client
     :raises Exception
     """
-    logger.info('Validate K8s Volumes')
-    pvol_list = cluster_client.list_persistent_volume()
-    for pvol in pvol_list.items:
-        logger.info('pvol - \n%s', pvol)
-
-    pv_claims = config_utils.get_persist_vol_claims(k8s_conf)
-    ceph_claims = config_utils.get_ceph_claims(k8s_conf)
-    claims = cluster_client.list_persistent_volume_claim_for_all_namespaces()
-    for claim in claims.items:
-        logger.info('claim - \n%s', claim)
-    pass
+    __validate_host_vols(k8s_conf, core_client)
+    # TODO/FIXME - Add Ceph volume check after Ceph support has been fixed
 
 
-def __get_pods_by_namespace(cluster_client, namespace):
+def __validate_host_vols(k8s_conf, core_client):
+    """
+    Validation of the configured kubernetes volumes
+    :param k8s_conf: the k8s configuration used to deploy the cluster
+    :param core_client: the k8s core API client
+    :raises Exception
+    """
+    logger.info('Validate K8s Host Volumes')
+    pv_list = core_client.list_persistent_volume()
+    host_vol_conf = __get_host_vol_dict(k8s_conf)
+    for pv in pv_list.items:
+        pv_name = pv.metadata.name
+        assert host_vol_conf.get(pv_name) is not None
+        pv_size = pv.spec.capacity['storage']
+        assert pv_size == host_vol_conf.get(pv_name)
+
+    pv_claims = core_client.list_persistent_volume_claim_for_all_namespaces()
+    for pv_claim in pv_claims.items:
+        pvc_name = pv_claim.metadata.name
+        assert host_vol_conf.get(pvc_name) is not None
+        pvc_size = pv_claim.status.capacity['storage']
+        assert pvc_size == host_vol_conf.get(pvc_name)
+
+
+def __get_expected_networks(k8s_conf):
+    """
+    Returns a list of configured CNI network instances
+    :param k8s_conf: the k8s configuration used to deploy the cluster
+    :raises Exception
+    """
+    # TODO/FIXME - Need to find the correct API to retrieve network instances
+    conf_networks = __get_expected_networks(k8s_conf)
+    net_client = k8s_net_client(k8s_conf)
+
+    net_client.lis()
+    out_nets = list()
+    out_nets.append(config_utils.get_default_network(
+        k8s_conf)[consts.NETWORK_NAME_KEY])
+    mult_net_types = config_utils.get_multus_net_elems(k8s_conf)
+
+
+def __get_host_vol_dict(k8s_conf):
+    """
+    Returns a dict of configured host volumes where the key is the name and
+    the value is the size
+    :param k8s_conf: the k8s configuration used to deploy the cluster
+    :return: dict
+    :raises Exception
+    """
+    out = dict()
+    host_vols = config_utils.get_host_vol(k8s_conf)
+    for host_vol in host_vols:
+        host_dict = host_vol[consts.CLAIM_PARAMS_KEY]
+        out[host_dict[consts.CLAIM_NAME_KEY]] = host_dict[consts.STORAGE_KEY]
+    return out
+
+
+def __get_pods_by_namespace(core_client, namespace):
     """
     Retrieves the pods for a given namespace
-    :param cluster_client: the kubernetes API client
+    :param core_client: the kubernetes API client
     :param namespace: the namespace of the pod to add into the return list
     :return: list of pod item objects
     """
     out_pods = list()
 
-    pod_list = cluster_client.list_pod_for_all_namespaces()
+    pod_list = core_client.list_pod_for_all_namespaces()
     pod_items = pod_list.items
 
     for pod_item in pod_items:

--- a/snaps_k8s/common/utils/validation_utils.py
+++ b/snaps_k8s/common/utils/validation_utils.py
@@ -164,45 +164,45 @@ def validate_count_master_minion(config):
 
 
 def __validate_load_balancer_ip(api_ext_loadbalancer_dict, hostname_map):
-        """
-        function to validate  loadbalancer ip must not be same as
-        master/minion ip
-        :param api_ext_loadbalancer_dict:
-        :param hostname_map:
-        :return:
-        """
-        logger.info("Argument List:\n api_ext_loadbalancer_dict: %s\n "
-                    "hostname_map: %s", api_ext_loadbalancer_dict,
-                    hostname_map)
-        for host in hostname_map:
-            if hostname_map[host] == api_ext_loadbalancer_dict.get(
-                    consts.HA_API_EXT_LB_KEY).get(consts.IP_KEY):
-                logger.info('Alert !! load balancer ip must not be '
-                            'same as master/minion ip')
-                return False
-        return True
+    """
+    function to validate  loadbalancer ip must not be same as
+    master/minion ip
+    :param api_ext_loadbalancer_dict:
+    :param hostname_map:
+    :return:
+    """
+    logger.info("Argument List:\n api_ext_loadbalancer_dict: %s\n "
+                "hostname_map: %s", api_ext_loadbalancer_dict,
+                hostname_map)
+    for host in hostname_map:
+        if hostname_map[host] == api_ext_loadbalancer_dict.get(
+                consts.HA_API_EXT_LB_KEY).get(consts.IP_KEY):
+            logger.info('Alert !! load balancer ip must not be '
+                        'same as master/minion ip')
+            return False
+    return True
 
 
 def __validate_load_balancer_port(api_ext_loadbalancer_dict):
-        """
-        function to validate  loadbalancer port must not be same as master
-        api server default port 6443
-        :param api_ext_loadbalancer_dict:
-        :return:
-        """
-        logger.info("Argument List:\n api_ext_loadbalancer_dict: %s",
-                    api_ext_loadbalancer_dict)
-        lb_port = api_ext_loadbalancer_dict.get(
-            consts.HA_API_EXT_LB_KEY).get("port")
-        if lb_port == 6443:
-            logger.info('Alert !! load balancer port must not be same as '
-                        'master api server default port 6443  ')
-            return False
-        elif lb_port == "":
-            logger.info('Alert !! load balancer port must not be null/empty ')
-            return False
+    """
+    function to validate  loadbalancer port must not be same as master
+    api server default port 6443
+    :param api_ext_loadbalancer_dict:
+    :return:
+    """
+    logger.info("Argument List:\n api_ext_loadbalancer_dict: %s",
+                api_ext_loadbalancer_dict)
+    lb_port = api_ext_loadbalancer_dict.get(
+        consts.HA_API_EXT_LB_KEY).get("port")
+    if lb_port == 6443:
+        logger.info('Alert !! load balancer port must not be same as '
+                    'master api server default port 6443  ')
+        return False
+    elif lb_port == "":
+        logger.info('Alert !! load balancer port must not be null/empty ')
+        return False
 
-        return True
+    return True
 
 
 def validate_countmasters(config):

--- a/snaps_k8s/playbooks/k8/ceph_delete_secret.yaml
+++ b/snaps_k8s/playbooks/k8/ceph_delete_secret.yaml
@@ -20,9 +20,12 @@
   tasks:
   - name: Deleting secret ceph-secret1
     command: "kubectl --kubeconfig={{ PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml delete secret ceph-secret1"
+    ignore_errors: true
 
   - name: Deleting secret ceph-secret-kube1
     command: "kubectl --kubeconfig={{ PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml delete secret ceph-secret-kube1"
+    ignore_errors: true
 
   - name: deleting already existing storage class
     command: "kubectl --kubeconfig={{ PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml delete sc fast-rbd2"
+    ignore_errors: true

--- a/snaps_k8s/playbooks/k8/ceph_volume2_final.yaml
+++ b/snaps_k8s/playbooks/k8/ceph_volume2_final.yaml
@@ -103,21 +103,21 @@
 
   - name: edit storage name in ceph-vc.yml
     lineinfile:
-         dest: "{{ SRC_PACKAGE_PATH }}../ceph-vc.yml"
+         dest: "{{ SRC_PACKAGE_PATH }}/packages/source/ceph-vc.yml"
          regexp: 'storage:'
          line: '      storage: {{Ceph_storage}}'
     delegate_to: "localhost"
 
   - name: modified claim name in "ceph-vc.yml"
     lineinfile:
-         dest: "{{ SRC_PACKAGE_PATH }}../ceph-vc.yml"
+         dest: "{{ SRC_PACKAGE_PATH }}/packages/source/ceph-vc.yml"
          regexp: 'name:'
          line: '  name: {{ ceph_claim_name }}'
     delegate_to: "localhost"
 
   - name: edit ip in ceph-storage-fast_rbd.yml
     lineinfile:
-         dest: "{{ SRC_PACKAGE_PATH }}../ceph-storage-fast_rbd.yml"
+         dest: "{{ SRC_PACKAGE_PATH }}/packages/source/ceph-storage-fast_rbd.yml"
          regexp: 'monitors:'
          line: '  monitors: {{ ceph_controller_ip }}:6789'
     delegate_to: "localhost"
@@ -129,9 +129,7 @@
        http_proxy: ""
        https_proxy: ""
        no_proxy: ""
-
     ignore_errors: true
-    delegate_to: "localhost"
     register: cat
   - debug: var=cat.stdout_lines
 

--- a/snaps_k8s/playbooks/k8/ceph_volume_final.yaml
+++ b/snaps_k8s/playbooks/k8/ceph_volume_final.yaml
@@ -21,56 +21,6 @@
   become_method: sudo
 
   tasks:
-    - name: edit file /etc/hosts
-      lineinfile:
-        dest: /etc/hosts
-        line: "{{ osd_ip }} {{ osd_host_name }}"
-      ignore_errors: true
-
-     - shell: rm /root/.ssh/id_rsa
-       ignore_errors: true
-     - shell: echo -e y|ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N ""
-       ignore_errors: true
-
-     - shell: sshpass -p {{ passwd }} ssh-copy-id -o StrictHostKeyChecking=no {{ user_id }}@{{ osd_host_name }}
-       ignore_errors: true
-
-     - shell: sshpass -p {{ passwd }} ssh-copy-id -o StrictHostKeyChecking=no {{ user_id }}@{{ osd_host_name }}
-       ignore_errors: true
-
-    - name: ceph-deploy forgetkeys
-      shell: ceph-deploy forgetkeys
-      ignore_errors: true
-
-    - name: ceph-deploy purge {{ osd_host_name }}
-      shell: ceph-deploy purge {{ osd_host_name }}
-      ignore_errors: true
-
-    - name: ceph-deploy purgedata {{ osd_host_name }} 
-      shell: ceph-deploy purgedata {{ osd_host_name }}
-      ignore_errors: true
-
-    - name: rm -f /etc/ceph/ceph.conf
-      command: rm -f /etc/ceph/ceph.conf
-      delegate_to: "{{ osd_host_name }}"
-      ignore_errors: true
-
-    - name: deleting already existing file
-      file:
-       state: absent
-       path: /var/lib/ceph/osd
-      ignore_errors: true
-
-    - name: apt-get remove -y ceph-deploy
-      shell: apt-get remove -y ceph-deploy
-      ignore_errors: true
-
-    - name: deleting already existing directory
-      file:
-       state: absent
-       path: /home/cluster-ceph
-      ignore_errors: true
-
     - name: wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add -
       shell: wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add -
       register: cat
@@ -90,8 +40,8 @@
        path: /home/cluster-ceph
        mode: 0644
 
-    - name: ceph-deploy new {{ host_name }}
-      command: ceph-deploy new {{ host_name }}
+    - name: ceph-deploy new {{ osd_host_name }}
+      command: ceph-deploy new {{ osd_host_name }}
       args:
         chdir: /home/cluster-ceph
       register: cat

--- a/snaps_k8s/playbooks/k8/ceph_volume_storage_type_final.yaml
+++ b/snaps_k8s/playbooks/k8/ceph_volume_storage_type_final.yaml
@@ -37,7 +37,7 @@
 
    - name: apt-get install -y parted
      apt:
-      name parted
+       name: parted
 
    - name: parted -s {{ storage }} mklabel gpt mkpart primary xfs 0% 100%
      command: parted -s {{ storage }} mklabel gpt mkpart primary xfs 0% 100%

--- a/snaps_k8s/playbooks/k8/launcher_setup.yaml
+++ b/snaps_k8s/playbooks/k8/launcher_setup.yaml
@@ -47,6 +47,21 @@
       regexp: 'kube_version:.*'
       replace: 'kube_version: {{ kube_version }} '
 
+  - name: set kube version in {{ PROJ_ARTIFACT_DIR }}/k8s-cluster.yml
+    replace:
+      dest: "{{ PROJ_ARTIFACT_DIR }}/k8s-cluster.yml"
+      regexp: 'kube_version:.*'
+      replace: 'kube_version: {{ kube_version }} '
+
+  - name: add kubelet_custom_flags  to {{ PROJ_ARTIFACT_DIR }}/k8s-cluster.yml
+    lineinfile:
+      path: "{{ PROJ_ARTIFACT_DIR }}/k8s-cluster.yml"
+      line: 'kubelet_custom_flags:'
+  - name: add kubelet_custom_flag value [--fail-swap-on=false]  to {{ PROJ_ARTIFACT_DIR }}/k8s-cluster.yml
+    lineinfile:
+      path: "{{ PROJ_ARTIFACT_DIR }}/k8s-cluster.yml"
+      line: '- "--fail-swap-on=false"'
+
   - name: copying "{{ PROJ_ARTIFACT_DIR }}/inventory.cfg" to "{{ KUBESPRAY_PATH }}/kubespray/inventory/sample/inventory.cfg"
     copy:
       src: "{{ PROJ_ARTIFACT_DIR }}/inventory.cfg"

--- a/snaps_k8s/playbooks/k8/macvlan_network_creation.yaml
+++ b/snaps_k8s/playbooks/k8/macvlan_network_creation.yaml
@@ -68,6 +68,8 @@
     command: "{{ item }}"
     with_items:
         - "kubectl --kubeconfig={{ PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml create -f /home/{{ network_name }}_file.conf"
+    retries: 3
+    delay: 3
     delegate_to: "localhost"
 
   - stat: path=/home/{{ network_name }}_file.conf

--- a/snaps_k8s/playbooks/k8/setup_k8.yaml
+++ b/snaps_k8s/playbooks/k8/setup_k8.yaml
@@ -54,7 +54,6 @@
       - libtool
       - pkg-config
       - python-opengl
-      - python-imaging
       - python-pyrex
       - python-pyside.qtopengl
       - idle-python2.7


### PR DESCRIPTION
#### What does this PR do?
Adds the ability to switch deploying snaps-kubernetes on Ubuntu 16.04 (default) or 18.04 by setting the optional argument 'ubuntu_version'. When set to '18' an Ubuntu 18.04 cloud image will be leveraged, else the same 16.04 image will be used as before.

The PR also adds dynamic validation routines using the kubernetes python API where it queries Kubernetes for objects it expects to be deployed.

Fixes #164 
#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
run CI locally
PR https://github.com/cablelabs/snaps-config/pull/85 must be merged and refreshed on the CI server else validation may fail or return a false positive
#### Any background context you want to provide?
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
- Does the documentation need an update?
n/a
- Does this add new Python dependencies?
kubernetes
- Have you added unit or functional tests for this PR?
yes
- Does this patch update any configuration files?
It adds ceph configuration to the CI but Ceph is still broken. This PR simply removes all obvious issues with the current ceph implementation that should eventually be fixed with the 'ceph_refactor' branch.
