### PR TITLE
Added Ceph to CI scripts and fixed problems found while exercising

### DIFF
--- a/ci/playbooks/deploy_k8.yaml
+++ b/ci/playbooks/deploy_k8.yaml
@@ -41,6 +41,7 @@
       dirs: yes
       rsync_opts:
         - "--exclude=.idea"
+        - "--exclude=venv"
         - "--exclude=.git/objects/pack"
 
   - name: Install requirements-git.txt

--- a/ci/playbooks/templates/deployment.ha.yaml.j2
+++ b/ci/playbooks/templates/deployment.ha.yaml.j2
@@ -93,6 +93,27 @@ kubernetes:
     no_proxy: "127.0.0.1,localhost,{{ minion_admin_ip_1 }},{{ minion_admin_ip_2 }},{{ master_admin_ip_1 }},{{ master_admin_ip_2 }}"
   Persistent_Volumes:
     Ceph_Volume:
+    - host:
+        hostname: master
+        ip: {{ minion_admin_ip_1 }}
+        user: root
+        password: password
+        node_type: ceph_controller
+        Ceph_claims:
+        - claim_parameters:
+            claim_name: claim1
+            storage: 4Gi
+        - claim_parameters:
+            claim_name: claim2
+            storage: 5Gi
+    - host:
+        hostname: master
+        ip: {{ minion_admin_ip_1 }}
+        user: root
+        password: password
+        node_type: ceph_osd
+        second_storage:
+          - /dev/vdb
     Host_Volume:
     - claim_parameters:
         Claim_name: claim4

--- a/ci/playbooks/templates/deployment.yaml.j2
+++ b/ci/playbooks/templates/deployment.yaml.j2
@@ -48,74 +48,95 @@ kubernetes:
         password: {{ node_host_pass }}
         user: root
   Docker_Repo:
-       ip: {{ master_admin_ip }}
-       port: 4000
-       password: {{ node_host_pass }}
-       user: root
+    ip: {{ master_admin_ip }}
+    port: 4000
+    password: {{ node_host_pass }}
+    user: root
   proxies:
     ftp_proxy: ""
     http_proxy: ""
     https_proxy: ""
     no_proxy: "127.0.0.1,localhost,{{ minion_admin_ip }},{{ master_admin_ip }}"
   Persistent_Volumes:
-      Ceph_Volume:
-      Host_Volume:
-            - claim_parameters:
-                Claim_name: claim4
-                storage: 4Gi
-            - claim_parameters:
-                Claim_name: claim5
-                storage: 5Gi
+    Ceph_Volume:
+    - host:
+        hostname: master
+        ip: {{ master_admin_ip }}
+        user: root
+        password: password
+        node_type: ceph_controller
+        Ceph_claims:
+          - claim_parameters:
+              claim_name: claim1
+              storage: 4Gi
+          - claim_parameters:
+              claim_name: claim2
+              storage: 5Gi
+    - host:
+        hostname: master
+        ip: {{ master_admin_ip }}
+        user: root
+        password: password
+        node_type: ceph_osd
+        second_storage:
+        - /dev/vdb
+    Host_Volume:
+    - claim_parameters:
+        Claim_name: claim4
+        storage: 4Gi
+    - claim_parameters:
+        Claim_name: claim5
+        storage: 5Gi
   Networks:
-      - Default_Network:
-          networking_plugin: weave
-          service_subnet:  10.241.241.0/24
-          pod_subnet: 10.241.241.0/24
-          network_name: default-network
-          isMaster: "true"
-      - Multus_network:
-          - CNI:
-            - macvlan
-            - flannel
-            - dhcp
-          - CNI_Configuration:
-            - Flannel:
-                - flannel_network:
-                    network_name: flannel-network-1
-                    network: 172.16.0.0/18
-                    subnet: 24
-                    isMaster: "false"
-            - Weave:
-                  - weave_network:
-                        network_name: weave-network-1
-                        subnet: 10.80.0.0/24
-                        isMaster: "false"
-            - Macvlan:
-                  - macvlan_networks:
-                        hostname: minion
-                        gateway: 172.16.151.1
-                        ip: 172.16.151.145/24
-                        parent_interface: {{ admin_iface }}
-                        vlanid: 34
-                        master: {{ admin_iface }}.34
-                        network_name: macvlan34-conf-19march
-                        rangeEnd: 172.16.151.60
-                        rangeStart: 172.16.151.55
-                        routes_dst: 0.0.0.0/0
-                        subnet: 172.16.151.0/24
-                        type: host-local
-                        isMaster: "false"
-                  - macvlan_networks:
-                        hostname: minion
-                        gateway: 172.16.151.1
-                        ip: 172.16.151.144/24
-                        parent_interface: {{ admin_iface }}
-                        vlanid: 35
-                        master: {{ admin_iface }}.35
-                        network_name: macvlan35-conf-19march
-                        rangeEnd: 172.16.151.65
-                        rangeStart: 172.16.151.61
-                        routes_dst: 0.0.0.0/0
-                        subnet: 172.16.151.0/24
-                        type: dhcp
-                        isMaster: "false"
+  - Default_Network:
+      networking_plugin: weave
+      service_subnet:  10.241.241.0/24
+      pod_subnet: 10.241.241.0/24
+      network_name: default-network
+      isMaster: "true"
+  - Multus_network:
+    - CNI:
+      - macvlan
+      - flannel
+      - dhcp
+    - CNI_Configuration:
+      - Flannel:
+        - flannel_network:
+            network_name: flannel-network-1
+            network: 172.16.0.0/18
+            subnet: 24
+            isMaster: "false"
+      - Weave:
+        - weave_network:
+            network_name: weave-network-1
+            subnet: 10.80.0.0/24
+            isMaster: "false"
+      - Macvlan:
+        - macvlan_networks:
+            hostname: minion
+            gateway: 172.16.151.1
+            ip: 172.16.151.145/24
+            parent_interface: {{ admin_iface }}
+            vlanid: 34
+            master: {{ admin_iface }}.34
+            network_name: macvlan34-conf-19march
+            rangeEnd: 172.16.151.60
+            rangeStart: 172.16.151.55
+            routes_dst: 0.0.0.0/0
+            subnet: 172.16.151.0/24
+            type: host-local
+            isMaster: "false"
+        - macvlan_networks:
+            hostname: minion
+            gateway: 172.16.151.1
+            ip: 172.16.151.144/24
+            parent_interface: {{ admin_iface }}
+            vlanid: 35
+            master: {{ admin_iface }}.35
+            network_name: macvlan35-conf-19march
+            rangeEnd: 172.16.151.65
+            rangeStart: 172.16.151.61
+            routes_dst: 0.0.0.0/0
+            subnet: 172.16.151.0/24
+            type: dhcp
+            isMaster: "false"

--- a/ci/snaps/snaps_k8_tmplt.yaml
+++ b/ci/snaps/snaps_k8_tmplt.yaml
@@ -115,7 +115,7 @@ openstack:
         os_user:
           name: k8-deploy-user-{{ build_id }}
           project_name: k8-deploy-proj-{{ build_id }}
-        name: minion-vol
+        name: master-vol
         size: 50
   routers:
     - router:
@@ -215,6 +215,8 @@ openstack:
         flavor: k8-node-flavor-{{ build_id }}
         imageName: snaps-image-{{ build_id }}
         security_group_names: [k8-deploy-build-sg]
+        volume_names:
+          - master-vol
         cloud_init_timeout: 300
         ports:
           - port:
@@ -257,8 +259,6 @@ openstack:
         imageName: snaps-image-{{ build_id }}
         security_group_names: [k8-deploy-build-sg]
         cloud_init_timeout: 300
-        volume_names:
-          - minion-vol
         ports:
           - port:
               name: k8-deploy-admin-port-2

--- a/snaps_k8s/common/consts/consts.py
+++ b/snaps_k8s/common/consts/consts.py
@@ -182,8 +182,6 @@ KUBERNETES_WEAVE_SCOPE = pkg_resources.resource_filename(
     K8_ANSIBLE_PKG, 'k8_weave_scope.yaml')
 KUBERNETES_KUBE_PROXY = pkg_resources.resource_filename(
     K8_ANSIBLE_PKG, 'k8_kube_proxy.yaml')
-KUBERNETES_PERSISTENT_VOL = pkg_resources.resource_filename(
-    K8_ANSIBLE_PKG, 'persistent_volume.yaml')
 KUBERNETES_AUTHENTICATION = pkg_resources.resource_filename(
     K8_ANSIBLE_PKG, 'Authentication.yaml')
 ETCD_CHANGES = pkg_resources.resource_filename(
@@ -194,6 +192,8 @@ KUBERNETES_CEPH_ADD_HOSTS = pkg_resources.resource_filename(
     K8_ANSIBLE_PKG, 'ceph_add_hosts.yaml')
 KUBERNETES_CEPH_INSTALL = pkg_resources.resource_filename(
     K8_ANSIBLE_PKG, 'ceph_install.yaml')
+KUBERNETES_CEPH_VOL = pkg_resources.resource_filename(
+    K8_ANSIBLE_PKG, 'ceph_volume.yaml')
 KUBERNETES_PERSISTENT_VOLUME = pkg_resources.resource_filename(
     K8_ANSIBLE_PKG, 'persistent_volume.yaml')
 KUBERNETES_CEPH_PVC = pkg_resources.resource_filename(

--- a/snaps_k8s/playbooks/k8/ceph_add_hosts.yaml
+++ b/snaps_k8s/playbooks/k8/ceph_add_hosts.yaml
@@ -1,52 +1,72 @@
+# Copyright 2019 ARICENT HOLDINGS LUXEMBOURG SARL and Cable Television
+# Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is responsible for deploying Aricent_Iaas environments and
+# Kubernetes Services
 ---
 - hosts: localhost
 
+  gather_facts: no
+
   tasks:
-    - set_fact:
-        ceph_target: "{{ceph_hosts | from_yaml }}"
+  - set_fact:
+      ceph_target: "{{ceph_hosts | from_yaml }}"
 
-    - debug:
-        var: ceph_target
+  - debug:
+      var: ceph_target
 
-    - name: Add all instance private IPs to host group
-      add_host:
-          hostname: "{{ item.ip }}"
-          ansible_ssh_user: "{{item.user}}"
-          ansible_ssh_pass: "{{item.password}}"
-          groups: ceph_hosts_group
+  - name: Add all instance private IPs to host group
+    add_host:
+        hostname: "{{ item.ip }}"
+        ansible_ssh_user: "{{item.user}}"
+        ansible_ssh_pass: "{{item.password}}"
+        groups: ceph_hosts_group
+    with_items: "{{ ceph_target }}"
+
+  - name: check if keys present in host
+    stat:
+      path: ~/.ssh/id_rsa
+    register: stat_result
+
+  - name: keys generation
+    shell: ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -q -N ""
+    when: stat_result.stat.exists == False
+
+  - name: copy the public keys
+    command: cat ~/.ssh/id_rsa.pub
+    register: id
+
+  - debug:
+      var: id.stdout
+  - set_fact:
+      ceph_hosts_group: "{{hostvars[inventory_hostname].groups.ceph_hosts_group}}"
+  - debug:
+      var: ceph_hosts_group
+
+  - name: edit /etc/hosts file
+    become: yes
+    become_method: sudo
+    become_user: root
+    lineinfile:
+      dest: /etc/hosts
+      line: "{{item.ip}} {{item.hostname}}"
+    with_items: "{{ ceph_target }}"
+
+  - name: add to known hosts
+    shell: ssh-keyscan "{{ item.hostname }}" >> ~/.ssh/known_hosts
+    with_items: "{{ ceph_target }}"
+
+  - block:
+    - include: ceph_set_hostname.yaml ceph_hostname={{item.hostname}} ceph_ip={{item.ip}}
       with_items: "{{ ceph_target }}"
-
-
-    - name: check if keys present in host
-      stat:
-        path: /root/.ssh/id_rsa
-      register: stat_result
-
-    - name: keys generation
-      shell: ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N ""
-      when: stat_result.stat.exists == False
-
-    - name: copy the public keys
-      command: cat /root/.ssh/id_rsa.pub
-      register: id
-    - debug:
-        var: id.stdout
-    - set_fact:
-        ceph_hosts_group: "{{hostvars[inventory_hostname].groups.ceph_hosts_group}}"
-    - debug:
-        var: ceph_hosts_group
-
-    - name: edit /etc/hosts file
-      lineinfile:
-          dest: /etc/hosts
-          line: "{{item.ip}} {{item.hostname}}"
-      with_items: "{{ ceph_target }}"
-
-    - name: add to known hosts
-      shell: ssh-keyscan "{{ item.hostname }}" >> /root/.ssh/known_hosts
-      with_items: "{{ ceph_target }}"
-
-    - block:
-       - include: ceph_set_hostname.yaml ceph_hostname={{item.hostname}} ceph_ip={{item.ip}}
-         with_items: "{{ ceph_target }}"
-

--- a/snaps_k8s/playbooks/k8/ceph_claims.yaml
+++ b/snaps_k8s/playbooks/k8/ceph_claims.yaml
@@ -1,53 +1,71 @@
-- name: kubectl create secret generic ceph-secret1 --type="kubernetes.io/rbd" --from-literal=key='{{cat.stdout_lines[0]}}'
-  command: kubectl --kubeconfig={{PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml create secret generic ceph-secret1 --type="kubernetes.io/rbd" --from-literal=key='{{cat.stdout_lines[0]}}'
+# Copyright 2019 ARICENT HOLDINGS LUXEMBOURG SARL and Cable Television
+# Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+# This script is responsible for deploying Aricent_Iaas environments and
+# Kubernetes Services
+---
+- hosts: localhost
 
-- name: kubectl create secret generic ceph-secret-kube1 --type="kubernetes.io/rbd" --from-literal=key='{{cat.stdout_lines[0]}}' --namespace=default
-  command: kubectl --kubeconfig={{PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml create secret generic ceph-secret-kube1 --type="kubernetes.io/rbd" --from-literal=key='{{cat.stdout_lines[0]}}' --namespace=default
+  gather_facts: no
 
+  tasks:
+  - name: kubectl create secret generic ceph-secret1 --type="kubernetes.io/rbd" --from-literal=key='{{cat.stdout_lines[0]}}'
+    command: kubectl --kubeconfig={{PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml create secret generic ceph-secret1 --type="kubernetes.io/rbd" --from-literal=key='{{cat.stdout_lines[0]}}'
 
-- name: Deleting already existing claim
-  command: kubectl --kubeconfig={{PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml delete pvc {{Ceph_Claim_name}}
-  ignore_errors: true
+  - name: kubectl create secret generic ceph-secret-kube1 --type="kubernetes.io/rbd" --from-literal=key='{{cat.stdout_lines[0]}}' --namespace=default
+    command: kubectl --kubeconfig={{PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml create secret generic ceph-secret-kube1 --type="kubernetes.io/rbd" --from-literal=key='{{cat.stdout_lines[0]}}' --namespace=default
 
-- name: Grep Ceph Persistent volume if already created kubectl get pv | grep {{Ceph_Claim_name}} | cut -d ' ' -f 1
-  shell: kubectl --kubeconfig={{PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml get pv | grep {{Ceph_Claim_name}} | cut -d ' ' -f 1
-  ignore_errors: true
-  register: cat
+  - name: Deleting already existing claim
+    command: kubectl --kubeconfig={{PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml delete pvc {{Ceph_Claim_name}}
+    ignore_errors: true
 
-- debug: var=cat.stdout_lines[0]
+  - name: Grep Ceph Persistent volume if already created kubectl get pv | grep {{Ceph_Claim_name}} | cut -d ' ' -f 1
+    shell: kubectl --kubeconfig={{PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml get pv | grep {{Ceph_Claim_name}} | cut -d ' ' -f 1
+    ignore_errors: true
+    register: cat
 
-- name: Deleting already existing Ceph Persistant volume( kubectl delete pv {{cat.stdout_lines[0]}} )
-  command: kubectl --kubeconfig={{PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml delete pv {{cat.stdout_lines[0]}}
-  ignore_errors: true
+  - debug: var=cat.stdout_lines[0]
 
-- name: edit storage name in ceph-vc.yml
-  lineinfile:
-       dest: "{{SRC_PACKAGE_PATH}}/packages/source/ceph-vc.yml"
-       regexp: 'storage:'
-       line: '      storage: {{Ceph_storage}}'
+  - name: Deleting already existing Ceph Persistant volume( kubectl delete pv {{cat.stdout_lines[0]}} )
+    command: kubectl --kubeconfig={{PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml delete pv {{cat.stdout_lines[0]}}
+    ignore_errors: true
 
-- name: modified claim name in "ceph-vc.yml"
-  lineinfile:
-       dest: "{{SRC_PACKAGE_PATH}}/packages/source/ceph-vc.yml"
-       regexp: 'name:'
-       line: '  name: {{Ceph_Claim_name}}'
+  - name: edit storage name in ceph-vc.yml
+    lineinfile:
+         dest: "{{ PROJ_ARTIFACT_DIR }}/ceph-vc-{{ Ceph_Claim_name }}.yml"
+         regexp: 'storage:'
+         line: '      storage: {{Ceph_storage}}'
 
+  - name: modified claim name in "ceph-vc.yml"
+    lineinfile:
+         dest: "{{ PROJ_ARTIFACT_DIR }}/ceph-vc-{{ Ceph_Claim_name }}.yml"
+         regexp: 'name:'
+         line: '  name: {{Ceph_Claim_name}}'
 
-- name: edit ip in ceph-storage-fast_rbd.yml
-  lineinfile:
-       dest: "{{SRC_PACKAGE_PATH}}/packages/source/ceph-storage-fast_rbd.yml"
-       regexp: 'monitors:'
-       line: '  monitors: {{ceph_controller_ip}}:6789'
+  - name: edit ip in ceph-storage-fast_rbd.yml
+    lineinfile:
+         dest: "{{ PROJ_ARTIFACT_DIR }}/ceph-storage-fast_rbd.yml"
+         regexp: 'monitors:'
+         line: '  monitors: {{ceph_controller_ip}}:6789'
 
-- name: creating storage class
-  command: kubectl --kubeconfig={{PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml create -f "{{SRC_PACKAGE_PATH}}/packages/source/ceph-storage-fast_rbd.yml" --namespace=default
-  register: cat
-  ignore_errors: true
-- debug: var=cat.stdout_lines
+  - name: creating storage class
+    command: kubectl --kubeconfig={{PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml create -f "{{ PROJ_ARTIFACT_DIR }}/ceph-storage-fast_rbd-{{ Ceph_Claim_name }}.yml" --namespace=default
+    register: cat
+    ignore_errors: true
+  - debug: var=cat.stdout_lines
 
-- name: creating claim
-  command: kubectl --kubeconfig={{PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml create -f "{{SRC_PACKAGE_PATH}}/packages/source/ceph-vc.yml" --namespace=default
-  register: cat
-- debug: var=cat.stdout_lines
-
+  - name: creating claim
+    command: kubectl --kubeconfig={{PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml create -f "{{ PROJ_ARTIFACT_DIR }}/ceph-vc-{{ Ceph_Claim_name }}.yml" --namespace=default
+    register: cat
+  - debug: var=cat.stdout_lines

--- a/snaps_k8s/playbooks/k8/ceph_deploy.yaml
+++ b/snaps_k8s/playbooks/k8/ceph_deploy.yaml
@@ -1,81 +1,36 @@
-- name: configure monitor node
-  command: ceph-deploy new {{ceph_mon}}
+- name: configure monitor node - ceph-deploy new {{ ceph_mon }}
+  command: ceph-deploy --username root new {{ ceph_mon }}
   args:
-   chdir: /home/cluster-ceph-{{project_name}}
-  register: out
-  ignore_errors: True
-
-- debug: var=out
-
-- name: Validating deploy ceph mon on the monitor nodes
-  fail: msg="configure monitor node command failed"
-  when: out.rc != 0
-
+    chdir: "{{ PROJ_ARTIFACT_DIR }}/cluster-ceph"
 
 - name: edit ceph.conf file
   lineinfile:
-       dest: /home/cluster-ceph-{{project_name}}/ceph.conf
-       line: "osd pool default size = 1"
+    dest: "{{ PROJ_ARTIFACT_DIR }}/cluster-ceph/ceph.conf"
+    line: "osd pool default size = 1"
 
-- name: install ceph packages on all nodes
-  command: ceph-deploy install  {{ceph_all}}
+- name: install ceph packages to {{ ceph_all }}
+  command: ceph-deploy --username root install {{ ceph_all }}
   args:
-   chdir: /home/cluster-ceph-{{project_name}}
-  register: out
-  ignore_errors: True
-
-- debug: var=out
-
-- name: Validating ceph packages on all nodes
-  fail: msg="ceph package install command failed"
-  when: out.rc != 0
-
+    chdir: "{{ PROJ_ARTIFACT_DIR }}/cluster-ceph"
 
 - name: Create monitor keyringfile for monitor nodes
-  shell: ceph-deploy mon create-initial
+  command: ceph-deploy --overwrite-conf --username root mon create-initial
   args:
-   chdir: /home/cluster-ceph-{{project_name}}
-  register: out
-  ignore_errors: True
-
-- debug: var=out
-
-- name: Validating Create monitor keyringfile for monitor nodes
-  fail: msg="create mon keyring command failed"
-  when: out.rc != 0
-
+    chdir: "{{ PROJ_ARTIFACT_DIR }}/cluster-ceph"
 
 - name: gather keyring files file on all nodes
-  shell: ceph-deploy gatherkeys {{ceph_mon}}
+  command: ceph-deploy --username root gatherkeys {{ ceph_mon }}
   args:
-   chdir: /home/cluster-ceph-{{project_name}}
-  register: out
-  ignore_errors: True
+    chdir: "{{ PROJ_ARTIFACT_DIR }}/cluster-ceph"
 
-- debug: var=out
-
-- name: Validating gather keyring
-  fail: msg="gather keyring command failed"
-  when: out.rc != 0
-
-
-- include: prepare_disk.yaml second_storage={{item.second_storage}}
+- debug: var=ceph_target
+- include: prepare_disk.yaml hostname={{ osd_item.hostname }} storage={{ osd_item.second_storage }}
   with_items: "{{ ceph_target }}"
-  when:  item.node_type == "ceph_osd"
-
+  when:  osd_item.node_type == "ceph_osd"
+  loop_control:
+    loop_var: osd_item
 
 - name: configure ceph admin keyring
-  shell: ceph-deploy admin {{ceph_all}}
+  command: ceph-deploy --username root admin {{ ceph_all }}
   args:
-   chdir: /home/cluster-ceph-{{project_name}}
-  register: out
-  ignore_errors: True
-
-- debug: var=out
-
-- name: Validating configuring ceph admin keyring
-  fail: msg="configure ceph admin keyring command failed"
-  when: out.rc != 0
-
-
-
+    chdir: "{{ PROJ_ARTIFACT_DIR }}/cluster-ceph"

--- a/snaps_k8s/playbooks/k8/ceph_install.yaml
+++ b/snaps_k8s/playbooks/k8/ceph_install.yaml
@@ -1,5 +1,24 @@
+# Copyright 2019 ARICENT HOLDINGS LUXEMBOURG SARL and Cable Television
+# Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is responsible for deploying Aricent_Iaas environments and
+# Kubernetes Services
 ---
 - hosts: localhost
+
+  gather_facts: no
+
   environment:
     http_proxy: "{{ http_proxy | default('') }}"
     https_proxy: "{{ https_proxy | default('') }}"
@@ -11,39 +30,35 @@
     ceph_all: ""
 
   tasks:
-    - set_fact:
-        ceph_target: "{{ceph_hosts | from_yaml }}"
-    - set_fact:
-         ceph_mon: "{{ceph_mon + ' ' + item.hostname}}"
-      with_items: "{{ ceph_target }}"
-      when:  item.node_type == "ceph_controller"
-    - set_fact:
-         ceph_osd: "{{ceph_osd + ' ' + item.hostname}}"
-      with_items: "{{ ceph_target }}"
-      when:  item.node_type == "ceph_osd"
-    - set_fact:
-         ceph_unique: "{{ ceph_target | selectattr('ip') | map(attribute='ip') | list| unique }}"
-    - set_fact:
-         ceph_all: "{{ceph_all + ' ' + item}}"
-      with_items: "{{ ceph_unique }}"
+  - set_fact:
+      ceph_target: "{{ceph_hosts | from_yaml }}"
 
-    - debug:
-        var: ceph_target
+  - set_fact:
+       ceph_mon: "{{ceph_mon + ' ' + item.hostname}}"
+    with_items: "{{ ceph_target }}"
+    when:  item.node_type == "ceph_controller"
 
-    - debug:
-        var: ceph_osd
-    - debug:
-        var: ceph_mon
-    - debug:
-        var: ceph_unique
-    - debug:
-        msg: "/home/cluster-ceph-{{project_name}}"
-    - block:
-       - include: ceph_purge.yaml osd_host_name={{ceph_osd}}
-       - include: ceph_package_install.yaml
-       - include: ceph_volume.yaml second_storage={{item.second_storage}}
-         with_items: "{{ ceph_target }}"
-         when:  item.node_type == "ceph_osd"
+  - set_fact:
+       ceph_osd: "{{ceph_osd + ' ' + item.hostname}}"
+    with_items: "{{ ceph_target }}"
+    when:  item.node_type == "ceph_osd"
 
-       - include: ceph_deploy.yaml
+  - set_fact:
+       ceph_unique: "{{ ceph_target | selectattr('ip') | map(attribute='ip') | list| unique }}"
 
+  - set_fact:
+       ceph_all: "{{ceph_all + ' ' + item}}"
+    with_items: "{{ ceph_unique }}"
+
+  - debug:
+      var: ceph_target
+  - debug:
+      var: ceph_osd
+  - debug:
+      var: ceph_mon
+  - debug:
+      var: ceph_unique
+
+  - block:
+    - include: ceph_package_install.yaml
+    - include: ceph_deploy.yaml

--- a/snaps_k8s/playbooks/k8/ceph_package_install.yaml
+++ b/snaps_k8s/playbooks/k8/ceph_package_install.yaml
@@ -1,25 +1,35 @@
 - name: deleting already existing directory
+  become: yes
+  become_method: sudo
+  become_user: root
   file:
    state: absent
-   path: "/home/cluster-ceph-{{project_name}}"
+   path: "{{ PROJ_ARTIFACT_DIR }}/cluster-ceph"
   ignore_errors: true
 
 - name: Install the trusted key with wget -q -O- 'https://download.ceph.com/keys/release.asc' | sudo apt-key add -
+  become: yes
+  become_method: sudo
+  become_user: root
   shell: wget -q -O- 'https://download.ceph.com/keys/release.asc' | sudo apt-key add -
   register: cat
 - debug: var=cat.stdout_lines
 
 - name: Add Ceph repository to apt configuration
+  become: yes
+  become_method: sudo
+  become_user: root
   command: echo deb http://download.ceph.com/debian-jewel/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
   register: cat
 - debug: var=cat.stdout_lines
 
 - name: Update Packages
+  become: yes
+  become_method: sudo
+  become_user: root
   shell: sudo apt-get -qqy update && sudo apt-get install -qqy ceph-deploy
 
 - name: create directory cluster-ceph
   file:
     state: directory
-    path: /home/cluster-ceph-{{project_name}}
-    mode: 0644
-
+    path: "{{ PROJ_ARTIFACT_DIR }}/cluster-ceph"

--- a/snaps_k8s/playbooks/k8/ceph_purge.yaml
+++ b/snaps_k8s/playbooks/k8/ceph_purge.yaml
@@ -1,10 +1,5 @@
 - debug:
     var: ceph_target
-- name: rm -f /etc/ceph/ceph.conf
-  command: rm -f /etc/ceph/ceph.conf
-  delegate_to: "{{item.ip}}"
-  with_items: "{{ ceph_target }}"
-  ignore_errors: true
 
 - name: Deleting secret ceph-secret1
   command: kubectl --kubeconfig={{ PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml delete secret ceph-secret1
@@ -18,20 +13,32 @@
   command: kubectl --kubeconfig={{ PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml delete sc fast-rbd2
   ignore_errors: true
 
-- name: ceph-deploy forgetkeys
-  shell: ceph-deploy forgetkeys
-  ignore_errors: true
-
 - name: ceph-deploy purge {{ceph_all}}
-  shell: ceph-deploy purge {{ceph_all}}
+  become: yes
+  become_method: sudo
+  become_user: root
+  command: ceph-deploy --username root purge {{ceph_all}}
   ignore_errors: true
 
-- name: ceph-deploy purgedata {{ceph_all}}
-  shell: ceph-deploy purgedata {{ceph_all}}
+- name: ceph-deploy --username root purgedata {{ceph_all}}
+  become: yes
+  become_method: sudo
+  become_user: root
+  command: ceph-deploy --username root purgedata {{ceph_all}}
   ignore_errors: true
+
+- name: ceph-deploy forgetkeys
+  become: yes
+  become_method: sudo
+  become_user: root
+  command: ceph-deploy --username root forgetkeys
+  ignore_errors: true
+
 - name: deleting already existing file
+  become: yes
+  become_method: sudo
+  become_user: root
   file:
     state: absent
     dest: /var/lib/ceph/osd
   ignore_errors: true
-

--- a/snaps_k8s/playbooks/k8/ceph_pvc.yaml
+++ b/snaps_k8s/playbooks/k8/ceph_pvc.yaml
@@ -1,51 +1,68 @@
----
+# Copyright 2019 ARICENT HOLDINGS LUXEMBOURG SARL and Cable Television
+# Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+# This script is responsible for deploying Aricent_Iaas environments and
+# Kubernetes Services
+---
 - hosts: localhost
+
+  gather_facts: no
+
   environment:
     http_proxy: "{{ http_proxy | default('') }}"
     https_proxy: "{{ https_proxy | default('') }}"
     no_proxy: "{{ no_proxy | default('') }}"
 
-
   tasks:
-    - set_fact:
-        ceph_target: "{{ceph_hosts | from_yaml }}"
-    - set_fact:
-        ceph_claim: "{{ceph_claims | from_yaml }}"
-    - set_fact:
-         ceph_controller_ip: "{{ item.ip}}"
-      with_items: "{{ ceph_target }}"
-      when:  item.node_type == "ceph_controller"
-    - debug:
-       var: SRC_PACKAGE_PATH
-    - debug:
-       var: KUBERNETES_PATH
-    - name: copy file ceph-storage-fast_rbd.yml to build server at path "{{KUBERNETES_PATH}}"
-      copy: src="{{SRC_PACKAGE_PATH}}/packages/source/ceph-storage-fast_rbd.yml" dest="{{KUBERNETES_PATH}}"
+  - set_fact:
+      ceph_target: "{{ceph_hosts | from_yaml }}"
+  - set_fact:
+      ceph_claim: "{{ceph_claims | from_yaml }}"
+  - set_fact:
+       ceph_controller_ip: "{{ item.ip}}"
+    with_items: "{{ ceph_target }}"
+    when:  item.node_type == "ceph_controller"
 
-    - name: copy file ceph-vc.yml to  build server at path "{{KUBERNETES_PATH}}"
-      copy: src="{{SRC_PACKAGE_PATH}}/packages/source/ceph-vc.yml" dest="{{KUBERNETES_PATH}}"
+  - name: copy file ceph-storage-fast_rbd.yml to build server at path "{{ PROJ_ARTIFACT_DIR }}"
+    copy:
+      src: "{{SRC_PACKAGE_PATH}}/packages/source/ceph-storage-fast_rbd.yml"
+      dest: "{{ PROJ_ARTIFACT_DIR }}/ceph-storage-fast_rdb-{{ item.claim_parameters.claim_name }}.yml"
 
-    - name: create pool at ceph cluster
-      shell: sudo ceph --cluster ceph osd pool create kube 1024 1024
-      delegate_to: "{{ item.ip }}"
-      with_items: "{{ ceph_target }}"
-      when: item.node_type == "ceph_controller"
+  - name: copy file ceph-vc.yml to  build server at path "{{ PROJ_ARTIFACT_DIR }}/ceph-vc-{{ item.claim_parameters.claim_name }}.yml"
+    copy:
+      src: "{{SRC_PACKAGE_PATH}}/packages/source/ceph-vc.yml"
+      dest: "{{ PROJ_ARTIFACT_DIR }}/ceph-vc-{{ item.claim_parameters.claim_name }}.yml"
+
+  - name: create pool at ceph cluster
+    shell: sudo ceph --cluster ceph osd pool create kube 1024 1024
+    delegate_to: "{{ item.ip }}"
+    with_items: "{{ ceph_target }}"
+    when: item.node_type == "ceph_controller"
+    ignore_errors: true
+
+  - name: Grep keyring
+
+    shell: grep key "~/cluster-ceph-{{ project_name }}/ceph.client.admin.keyring" | cut -d ' ' -f 3
+
+    ignore_errors: true
+    register: cat
+    run_once: True
+
+  - debug: var=cat.stdout_lines[0]
+    ignore_errors: true
+
+  - block:
+    - include: ceph_claims.yaml Ceph_Claim_name={{item.claim_parameters.claim_name}} Ceph_storage={{item.claim_parameters.storage}}
       ignore_errors: true
-
-    - name: Grep keyring
-
-      shell: grep key "/home/cluster-ceph-{{project_name}}/ceph.client.admin.keyring" | cut -d ' ' -f 3
-
-      ignore_errors: true
-      register: cat
-      run_once: True
-
-    - debug: var=cat.stdout_lines[0]
-      ignore_errors: true
-
-    - block:
-      - include: ceph_claims.yaml Ceph_Claim_name={{item.claim_parameters.claim_name}}  Ceph_storage={{item.claim_parameters.storage}}
-        ignore_errors: true
-        with_items: "{{ ceph_claim }}"
-
+      with_items: "{{ ceph_claim }}"

--- a/snaps_k8s/playbooks/k8/ceph_set_hostname.yaml
+++ b/snaps_k8s/playbooks/k8/ceph_set_hostname.yaml
@@ -1,20 +1,28 @@
 - debug:
     var: item.ip
   delegate_to: "{{ item.ip }}"
+
 - lineinfile:
-    dest: /root/.ssh/authorized_keys
+    dest: ~/.ssh/authorized_keys
     line: "{{ id.stdout }}"
     create: yes
   delegate_to: "{{ item.ip }}"
+
 - name: change host name to "{{ceph_hostname}}"
   command: hostname "{{ceph_hostname}}"
   delegate_to: "{{ item.ip }}"
 
 - name: remove /etc/hostname
+  become: yes
+  become_method: sudo
+  become_user: root
   shell: echo "{{ceph_hostname}}" > /etc/hostname
   delegate_to: "{{ item.ip }}"
 
 - name: edit /etc/hosts file
+  become: yes
+  become_method: sudo
+  become_user: root
   lineinfile:
        dest: /etc/hosts
        line: "{{ceph_ip}} {{ceph_hostname}}"

--- a/snaps_k8s/playbooks/k8/ceph_volume.yaml
+++ b/snaps_k8s/playbooks/k8/ceph_volume.yaml
@@ -1,46 +1,48 @@
-- debug:
-    var: ceph_target
-  delegate_to: "{{item.ip}}"
-- debug:
-    var: second_storage
-  delegate_to: "{{item.ip}}"
+# Copyright 2019 ARICENT HOLDINGS LUXEMBOURG SARL and Cable Television
+# Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-- name: install parted
-  shell: apt-get install -y parted
-  delegate_to: "{{item.ip}}"
+# This script is responsible for deploying Aricent_Iaas environments and
+# Kubernetes Services
+---
+- hosts: all
 
-- name: "sudo parted -s {{ceph_item}} mklabel gpt mkpart primary xfs 0% 100%"
-  command: "sudo parted -s {{ceph_item}} mklabel gpt mkpart primary xfs 0% 100%"
-  with_items: "{{second_storage}}"
-  loop_control:
-     loop_var: ceph_item
-  delegate_to: "{{item.ip}}"
+  gather_facts: no
 
-- name: "sudo mkfs.xfs -f {{ceph_item}}"
-  command: "sudo mkfs.xfs -f {{ceph_item}}"
-  with_items: "{{second_storage}}"
-  loop_control:
-     loop_var: ceph_item
-  register: cat
-  delegate_to: "{{item.ip}}"
-- debug: var=cat.stdout_lines
+  become: yes
+  become_method: sudo
+  become_user: root
 
-- name: "sudo fdisk -s {{ceph_item}}"
-  command: "sudo fdisk -s {{ceph_item}}"
-  with_items: "{{second_storage}}"
-  loop_control:
-     loop_var: ceph_item
-  register: cat
-  delegate_to: "{{item.ip}}"
-- debug: var=cat.stdout_lines
+  tasks:
+  - debug:
+      var: second_storage
 
-- name: "sudo blkid -o value -s TYPE {{ceph_item}}"
-  command: "sudo blkid -o value -s TYPE {{ceph_item}}"
-  with_items: "{{second_storage}}"
-  loop_control:
-     loop_var: ceph_item
-  register: cat
-  delegate_to: "{{item.ip}}"
-- debug: var=cat.stdout_lines
+  - name: install parted
+    apt:
+      name: apt
 
+  - name: "sudo parted -s {{ item }} mklabel gpt mkpart primary xfs 0% 100%"
+    command: "sudo parted -s {{ item }} mklabel gpt mkpart primary xfs 0% 100%"
+    with_items: "{{ second_storage }}"
 
+  - name: "sudo mkfs.xfs -f {{ item }}"
+    command: "sudo mkfs.xfs -f {{ item }}"
+    with_items: "{{ second_storage }}"
+
+  - name: "sudo fdisk -s {{ item }}"
+    command: "sudo fdisk -s {{ item }}"
+    with_items: "{{ second_storage }}"
+
+  - name: "sudo blkid -o value -s TYPE {{ item }}"
+    command: "sudo blkid -o value -s TYPE {{ item }}"
+    with_items: "{{ second_storage }}"

--- a/snaps_k8s/playbooks/k8/flannel_intf_master.yaml
+++ b/snaps_k8s/playbooks/k8/flannel_intf_master.yaml
@@ -16,57 +16,66 @@
 # Kubernetes Services
 # This playbook configure flannel interface at master.
 ---
-
 - hosts: "{{ host_name }}"
+
+  gather_facts: no
+
   become: true
   become_user: root
+  become_method: sudo
+
   vars:
-    - src_package_path: "{{ SRC_PACKAGE_PATH }}"
-    - networking_plugin: "{{ networking_plugin }}"
-    - VNI: "{{ vni }}"
+  - src_package_path: "{{ SRC_PACKAGE_PATH }}"
+  - networking_plugin: "{{ networking_plugin }}"
+  - VNI: "{{ vni }}"
+
   tasks:
-    - name: cp flannel base file 
-      copy: src="{{SRC_PACKAGE_PATH}}/packages/source/multus_cni/flannel/Bk_flannel-config.json" dest=/etc/kubernetes/flannel-config.json
+  - name: cp flannel base file
+    copy:
+      src: "{{SRC_PACKAGE_PATH}}/packages/source/multus_cni/flannel/Bk_flannel-config.json"
+      dest: /etc/kubernetes/flannel-config.json
 
-    - name: write data in flannel-config.json file
-      replace:
-        dest: /etc/kubernetes/flannel-config.json
-        regexp: 'Network'
-        replace: '"Network" : "{{ network }}"'
+  - name: write data in flannel-config.json file
+    replace:
+      dest: /etc/kubernetes/flannel-config.json
+      regexp: 'Network'
+      replace: '"Network" : "{{ network }}"'
 
-    - name: write data in flannel-config.json file
-      replace:
-        dest: /etc/kubernetes/flannel-config.json
-        regexp: 'SubnetLen'
-        replace: '"SubnetLen" : {{ subnetLen }}'
-    
-    - name: write data in flannel-config.json file
-      replace:
-        dest: /etc/kubernetes/flannel-config.json
-        regexp: 'VNI'
-        replace: '"VNI" : {{ vni }}'
-    
-    - name: cp flannel binary 
-      copy: src="{{SRC_PACKAGE_PATH}}/packages/source/multus_cni/master/flanneld-amd64" dest=/root/.
-      when: VNI == "1"
+  - name: write data in flannel-config.json file
+    replace:
+      dest: /etc/kubernetes/flannel-config.json
+      regexp: 'SubnetLen'
+      replace: '"SubnetLen" : {{ subnetLen }}'
 
-    - name: change permissions for flannel binary
-      shell: chmod 777 flanneld-amd64
-      when: VNI == "1"
-      args:
-       chdir: "/root"
+  - name: write data in flannel-config.json file
+    replace:
+      dest: /etc/kubernetes/flannel-config.json
+      regexp: 'VNI'
+      replace: '"VNI" : {{ vni }}'
 
-    - name: load flannel configuration
-      shell: etcdctl --endpoints https://"{{ ip }}":2379 set kubernetes-cluster/network/config < /etc/kubernetes/flannel-config.json
+  - name: cp flannel binary
+    copy:
+      src: "{{SRC_PACKAGE_PATH}}/packages/source/multus_cni/master/flanneld-amd64"
+      dest: /root/.
+    when: VNI == "1"
 
-    - name: run flannel binary
-      shell: ./flanneld-amd64 -etcd-endpoints https://"{{ ip }}":2379 -etcd-prefix=kubernetes-cluster/network &
-      when: VNI == "1"
-      args:
-       chdir: "/root"
+  - name: change permissions for flannel binary
+    shell: chmod 777 flanneld-amd64
+    when: VNI == "1"
+    args:
+     chdir: "/root"
 
-    - name: run flannel binary
-      shell: ./flanneld-amd64 -etcd-endpoints https://"{{ ip }}":2379 -etcd-prefix=kubernetes-cluster/network -subnet-file=/run/flannel/{{vni}}.env &
-      when: VNI > "1" 
-      args:
-       chdir: "/root"
+  - name: load flannel configuration
+    shell: etcdctl --endpoints https://"{{ ip }}":2379 set kubernetes-cluster/network/config < /etc/kubernetes/flannel-config.json
+
+  - name: run flannel binary
+    shell: ./flanneld-amd64 -etcd-endpoints https://"{{ ip }}":2379 -etcd-prefix=kubernetes-cluster/network &
+    when: VNI == "1"
+    args:
+     chdir: "/root"
+
+  - name: run flannel binary
+    shell: ./flanneld-amd64 -etcd-endpoints https://"{{ ip }}":2379 -etcd-prefix=kubernetes-cluster/network -subnet-file=/run/flannel/{{vni}}.env &
+    when: VNI > "1"
+    args:
+     chdir: "/root"

--- a/snaps_k8s/playbooks/k8/host_claims.yaml
+++ b/snaps_k8s/playbooks/k8/host_claims.yaml
@@ -1,37 +1,33 @@
 - name: edit storage in task-pv-volume.yaml
   lineinfile:
-       dest: "{{SRC_PACKAGE_PATH}}/packages/source/task-pv-volume.yaml"
+       dest: "{{ PROJ_ARTIFACT_DIR }}/task-pv-volume-{{ claim_name }}.yaml"
        regexp: 'storage:'
-       line: '       storage: {{Ceph_storage}}'
-
+       line: '       storage: {{ claim_storage }}'
 
 - name: edit pv name in task-pv-volume.yaml
   lineinfile:
-       dest: "{{SRC_PACKAGE_PATH}}/packages/source/task-pv-volume.yaml"
-       regexp: 'name:'
-       line: '  name: {{Ceph_Claim_name}}'
-
+    dest: "{{ PROJ_ARTIFACT_DIR }}/task-pv-volume-{{ claim_name }}.yaml"
+    regexp: 'name:'
+    line: '  name: {{ claim_name }}'
 
 - name: modified storage in task-pv-claim.yaml
   lineinfile:
-       dest: "{{SRC_PACKAGE_PATH}}/packages/source/task-pv-claim.yaml"
-       regexp: 'storage:'
-       line: '       storage: {{Ceph_storage}}'
-
+    dest: "{{ PROJ_ARTIFACT_DIR }}/task-pv-claim-{{ claim_name }}.yaml"
+    regexp: 'storage:'
+    line: '       storage: {{ claim_storage }}'
 
 - name: modified claim name in task-pv-claim.yaml
   lineinfile:
-       dest: "{{SRC_PACKAGE_PATH}}/packages/source/task-pv-claim.yaml"
-       regexp: 'name:'
-       line: '  name: {{Ceph_Claim_name}}'
-
+    dest: "{{ PROJ_ARTIFACT_DIR }}/task-pv-claim-{{ claim_name }}.yaml"
+    regexp: 'name:'
+    line: '  name: {{ claim_name }}'
 
 - name: kubectl delete pvc
-  command: kubectl --kubeconfig={{ PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml delete pvc "{{Ceph_Claim_name}}"
+  command: kubectl --kubeconfig={{ PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml delete pvc "{{ claim_name }}"
   ignore_errors: true
 
 - name: Create persistent volume
-  command: kubectl --kubeconfig={{ PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml create -f "{{SRC_PACKAGE_PATH}}/packages/source/task-pv-volume.yaml"
+  command: kubectl --kubeconfig={{ PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml create -f "{{ PROJ_ARTIFACT_DIR }}/task-pv-volume-{{ claim_name }}.yaml"
   register: cat
 - debug: var=cat.stdout_lines
 
@@ -42,10 +38,9 @@
 
 
 - name: Create a PVC
-  command: kubectl --kubeconfig={{ PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml create -f "{{SRC_PACKAGE_PATH}}/packages/source/task-pv-claim.yaml"
+  command: kubectl --kubeconfig={{ PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml create -f "{{ PROJ_ARTIFACT_DIR }}/task-pv-claim-{{ claim_name }}.yaml"
 
 - name: kubectl get pvc
   command: kubectl --kubeconfig={{ PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml get pvc
   register: cat
 - debug: var=cat.stdout_lines
-

--- a/snaps_k8s/playbooks/k8/k8_create_inventory_file.yaml
+++ b/snaps_k8s/playbooks/k8/k8_create_inventory_file.yaml
@@ -22,7 +22,6 @@
       file:
        state: directory
        path: "{{ PROJ_ARTIFACT_DIR }}"
-       mode: 0755
 
     - name: Copy inventery file to "{{ PROJ_ARTIFACT_DIR }}"
       copy:

--- a/snaps_k8s/playbooks/k8/persistent_volume.yaml
+++ b/snaps_k8s/playbooks/k8/persistent_volume.yaml
@@ -17,41 +17,32 @@
 ---
 
 - hosts: localhost
-  vars:
-    storage: "{{storage_size}}"
-    claim_name: "{{claim_name}}"
+
+  gather_facts: no
+
   environment:
     http_proxy: "{{ http_proxy | default('') }}"
     https_proxy: "{{ https_proxy | default('') }}"
     no_proxy: "{{ no_proxy | default('') }}"
 
   tasks:
-    - set_fact:
-        ceph_target: "{{ceph_hosts | from_yaml }}"
-    - set_fact:
-        persistent_volume: "{{persistent_vol | from_yaml }}"
-    - debug:
-        var: persistent_volume
-    - set_fact:
-         ceph_controller_ip: "{{ item.ip}}"
-      with_items: "{{ ceph_target }}"
-      when:  item.node_type == "ceph_controller"
-    - name: copy file task-pv-volume.yaml
-      copy: src="{{SRC_PACKAGE_PATH}}/packages/source/task-pv-volume.yaml" dest="{{KUBERNETES_PATH}}"
+  - set_fact:
+      persistent_volume: "{{ persistent_vol | from_yaml }}"
 
-    - name: copy file task-pv-claim.yaml
-      copy: src="{{SRC_PACKAGE_PATH}}/packages/source/task-pv-claim.yaml" dest="{{KUBERNETES_PATH}}"
+  - debug:
+      var: persistent_volume
 
-    - name: create directory /tmp/data
-      file:
-       state: directory
-       path: /tmp/data
-       mode: 0644
+  - name: copy file task-pv-volume.yaml to {{ PROJ_ARTIFACT_DIR }}/task-pv-volume-{{ item.Claim_name }}.yaml
+    copy:
+      src: "{{ SRC_PACKAGE_PATH }}/packages/source/task-pv-volume.yaml"
+      dest: "{{ PROJ_ARTIFACT_DIR }}/task-pv-volume-{{ item.Claim_name }}.yaml"
+    with_items: "{{ persistent_volume }}"
 
-    - block:
-      - include: host_claims.yaml Ceph_Claim_name={{item.Claim_name}}  Ceph_storage={{item.storage}}
-        ignore_errors: true
-        with_items: "{{ persistent_volume }}"
+  - name: copy file task-pv-claim.yaml to {{ PROJ_ARTIFACT_DIR }}/task-pv-claim-{{ item.Claim_name }}.yaml
+    copy:
+      src: "{{ SRC_PACKAGE_PATH }}/packages/source/task-pv-claim.yaml"
+      dest: "{{ PROJ_ARTIFACT_DIR }}/task-pv-claim-{{ item.Claim_name }}.yaml"
+    with_items: "{{ persistent_volume }}"
 
-
-
+  - include: host_claims.yaml claim_name={{ item.Claim_name }}  claim_storage={{ item.storage }}
+    with_items: "{{ persistent_volume }}"

--- a/snaps_k8s/playbooks/k8/prepare_disk.yaml
+++ b/snaps_k8s/playbooks/k8/prepare_disk.yaml
@@ -1,17 +1,18 @@
-- name: ceph-deploy disk zap {{item.hostname}}:{{ceph_item}}
-  shell: "ceph-deploy disk zap {{item.hostname}}:{{ceph_item}}"
+- set_fact:
+    sto_loc: "{{ storage | from_yaml }}"
+
+- name: ceph-deploy disk zap {{ hostname }}:{{ sto_item }}
+  shell: "ceph-deploy --username root disk zap {{ hostname }}:{{ sto_item }}"
   args:
-   chdir: /home/cluster-ceph-{{project_name}}
-  with_items: "{{second_storage}}"
+   chdir: "{{ PROJ_ARTIFACT_DIR }}/cluster-ceph"
+  with_items: "{{ storage }}"
   loop_control:
-     loop_var: ceph_item
+    loop_var: sto_item
 
-
-- name: ceph-deploy disk prepare  "{{item.hostname}}:{{ceph_item}}"
-  shell: "ceph-deploy disk prepare  {{item.hostname}}:{{ceph_item}}"
+- name: ceph-deploy disk prepare {{ hostname }}:{{ sto_item }}
+  shell: "ceph-deploy --username root disk prepare {{ hostname }}:{{ sto_item }}"
   args:
-   chdir: /home/cluster-ceph-{{project_name}}
-  with_items: "{{second_storage}}"
+   chdir: "{{ PROJ_ARTIFACT_DIR }}/cluster-ceph"
+  with_items: "{{ storage }}"
   loop_control:
-     loop_var: ceph_item
-
+    loop_var: sto_item

--- a/snaps_k8s/provision/ansible_configuration.py
+++ b/snaps_k8s/provision/ansible_configuration.py
@@ -613,15 +613,25 @@ def launch_ceph_kubernetes(k8s_conf):
         pb_vars = {
             'ceph_hosts': ceph_hosts
         }
-        ansible_utils.apply_playbook(consts.KUBERNETES_CEPH_ADD_HOSTS, variables=pb_vars)
+        ansible_utils.apply_playbook(consts.KUBERNETES_CEPH_ADD_HOSTS,
+                                     variables=pb_vars)
         pb_vars = {
             'ceph_hosts': ceph_hosts,
-            'project_name': config_utils.get_project_name(k8s_conf),
-            'PROJ_ARTIFACT_DIR': config_utils.get_project_artifact_dir(k8s_conf),
+            'PROJ_ARTIFACT_DIR': config_utils.get_project_artifact_dir(
+                k8s_conf),
         }
-
         pb_vars.update(config_utils.get_proxy_dict(k8s_conf))
-        ansible_utils.apply_playbook(consts.KUBERNETES_CEPH_INSTALL, variables=pb_vars)
+        ansible_utils.apply_playbook(consts.KUBERNETES_CEPH_INSTALL,
+                                     variables=pb_vars)
+    ceph_osd_hosts = config_utils.get_ceph_osds(k8s_conf)
+    for ceph_host in ceph_osd_hosts:
+        pb_vars = {
+            'second_storage': ceph_host[consts.STORAGE_TYPE_KEY],
+        }
+        pb_vars.update(config_utils.get_proxy_dict(k8s_conf))
+        ansible_utils.apply_playbook(
+            consts.KUBERNETES_CEPH_VOL, [ceph_host[consts.IP_KEY]],
+            consts.NODE_USER, variables=pb_vars)
 
     for ceph_mon in ceph_mon_list:
         claims = ceph_mon[consts.CEPH_CLAIMS_KEY]
@@ -629,14 +639,15 @@ def launch_ceph_kubernetes(k8s_conf):
             pb_vars = {
                 'ceph_hosts': ceph_hosts,
                 'SRC_PACKAGE_PATH': config_utils.get_artifact_dir(k8s_conf),
-                'KUBERNETES_PATH': consts.NODE_K8S_PATH,
                 'project_name': config_utils.get_project_name(k8s_conf),
                 'ceph_claims': claims,
-                'PROJ_ARTIFACT_DIR': config_utils.get_project_artifact_dir(k8s_conf),
+                'PROJ_ARTIFACT_DIR': config_utils.get_project_artifact_dir(
+                    k8s_conf),
             }
 
             pb_vars.update(config_utils.get_proxy_dict(k8s_conf))
-            ansible_utils.apply_playbook(consts.KUBERNETES_CEPH_PVC, variables=pb_vars)
+            ansible_utils.apply_playbook(consts.KUBERNETES_CEPH_PVC,
+                                         variables=pb_vars)
 
 
 def launch_persitent_volume_kubernetes(k8s_conf):
@@ -650,14 +661,13 @@ def launch_persitent_volume_kubernetes(k8s_conf):
         pb_vars = {
             'ceph_hosts': ceph_hosts,
             'SRC_PACKAGE_PATH': config_utils.get_artifact_dir(k8s_conf),
-            'KUBERNETES_PATH': consts.NODE_K8S_PATH,
-            'project_name': config_utils.get_project_name(k8s_conf),
             'persistent_vol': vol_claims,
-            'PROJ_ARTIFACT_DIR': config_utils.get_project_artifact_dir(k8s_conf),
+            'PROJ_ARTIFACT_DIR': config_utils.get_project_artifact_dir(
+                k8s_conf),
         }
-
         pb_vars.update(config_utils.get_proxy_dict(k8s_conf))
-        ansible_utils.apply_playbook(consts.KUBERNETES_PERSISTENT_VOLUME, variables=pb_vars)
+        ansible_utils.apply_playbook(consts.KUBERNETES_PERSISTENT_VOLUME,
+                                     variables=pb_vars)
 
 
 def __enable_cluster_logging(k8s_conf):


### PR DESCRIPTION
#### What does this PR do?
Deals with issues found around assuming the 'root' user will be kicking off iaas_launch.py. Additionally, fixed pv & pvc creation logic when multiple instances are configured for each type. Also removed a delegation from the master to the ceph node as they should not have direct ssh access to each other.
#### Do you have any concerns with this PR?
The first call to 'parted' is failing mklabel with '/dev/vdb' (the attached volume on the master where the ceph node is defined as the master as well)
#### How can the reviewer verify this PR?
Run the CI scripts and view the /tmp/k8s_deploy.log on the build VM
#### Any background context you want to provide?
Issues found while trying to add ceph to the CI scripts
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
n/a - Attempting to fix issues found on https://github.com/cablelabs/snaps-kubernetes/pull/169
- Does the documentation need an update?
n/a
- Does this add new Python dependencies?
no
- Have you added unit or functional tests for this PR?
no
- Does this patch update any configuration files?
no