### PR TITLE
Fix CI default networking config which will allow flannel to be properly installed by kubespray

### DIFF
--- a/ci/playbooks/templates/deployment.ha.yaml.j2
+++ b/ci/playbooks/templates/deployment.ha.yaml.j2
@@ -134,8 +134,6 @@ kubernetes:
         storage: 5Gi
   Networks:
   - Default_Network:
-      # TODO/FIXME - Determine why flannel, cilium, & contiv do not work here
-      # weave is working - calico ???
       networking_plugin: {{ networking_plugin }}
       service_subnet:  10.241.241.0/24
       pod_subnet: 10.241.251.0/24
@@ -146,33 +144,35 @@ kubernetes:
       - dhcp
       - macvlan
 {% if networking_plugin != 'weave' %}
-# TODO/FIXME - Weave network creation is broken
-#      - weave
+      - weave
 {% endif %}
-# TODO/FIXME - Flannel is broken with kubespray or how it is currently being configured
+{% if networking_plugin != 'flannel' %}
+# TODO/FIXME - Flannel is currently broken
 #      - flannel
+{% endif %}
     - CNI_Configuration:
       # TODO/FIXME - Flannel is not working
       - Flannel:
         - flannel_network:
             network_name: flannel-network-1
-            network: 10.2.0.0/18
-            subnet: 24
+            network: 10.2.0.0/16
+            subnet: 16
             isMaster: "false"
         - flannel_network:
             network_name: flannel-network-2
-            network: 10.2.1.0/18
-            subnet: 24
+            network: 10.3.0.0/16
+            subnet: 16
             isMaster: "false"
       - Weave:
+          # TODO/FIXME - Multiple weave networks are failing
         - weave_network:
             network_name: weave-network-1
-            subnet: 10.1.0.0/24
+            subnet: 10.4.0.0/16
             isMaster: "false"
-        - weave_network:
-            network_name: weave-network-2
-            subnet: 10.1.2.0/24
-            isMaster: "false"
+#        - weave_network:
+#            network_name: weave-network-2
+#            subnet: 10.5.0.0/16
+#            isMaster: "false"
       - Macvlan:
         - macvlan_networks:
             hostname: minion1

--- a/ci/playbooks/templates/deployment.yaml.j2
+++ b/ci/playbooks/templates/deployment.yaml.j2
@@ -102,13 +102,11 @@ kubernetes:
   - Default_Network:
       # TODO/FIXME - BROKEN CNI
       # cilium will cause kubespray to fail
-      # flannel does not work when kubespray or snaps attempts to deploy
       # WORKING PROPERLY
       # calico and contiv appears to deploy ok but observed some issues with rook and sonobuoy pods starting
-      # weave is the only CNI working properly when deployed by kubespray
       networking_plugin: {{ networking_plugin }}
-      service_subnet:  10.241.241.0/24
-      pod_subnet: 10.241.251.0/24
+      service_subnet:  10.241.0.0/16
+      pod_subnet: 10.251.0.0/16
       network_name: default-network
       isMaster: "true"
   - Multus_network:
@@ -119,34 +117,34 @@ kubernetes:
       - macvlan
 {% endif %}
 {% if networking_plugin != 'weave' %}
-# TODO/FIXME - Weave network creation is broken
-#      - weave
+      - weave
 {% endif %}
 {% if networking_plugin != 'flannel' %}
-# TODO/FIXME - Flannel is broken with kubespray or how it is currently being configured
+# TODO/FIXME - Flannel is currently broken
 #      - flannel
 {% endif %}
     - CNI_Configuration:
       - Flannel:
         - flannel_network:
             network_name: flannel-network-1
-            network: 10.2.0.0/18
-            subnet: 24
+            network: 10.2.0.0/16
+            subnet: 16
             isMaster: "false"
         - flannel_network:
             network_name: flannel-network-2
-            network: 10.2.1.0/18
-            subnet: 24
+            network: 10.3.0.0/16
+            subnet: 16
             isMaster: "false"
       - Weave:
+        # TODO/FIXME - Multiple weave networks are failing
         - weave_network:
             network_name: weave-network-1
-            subnet: 10.3.1.0/24
+            subnet: 10.4.0.0/16
             isMaster: "false"
-        - weave_network:
-            network_name: weave-network-2
-            subnet: 10.3.2.0/24
-            isMaster: "false"
+#        - weave_network:
+#            network_name: weave-network-2
+#            subnet: 10.5.0.0/16
+#            isMaster: "false"
       - Macvlan:
         - macvlan_networks:
             hostname: minion

--- a/ci/playbooks/templates/deployment.yaml.j2
+++ b/ci/playbooks/templates/deployment.yaml.j2
@@ -100,10 +100,9 @@ kubernetes:
         storage: 5Gi
   Networks:
   - Default_Network:
-      # TODO/FIXME - BROKEN CNI
+      # calico & contiv will cause CNCF tests to fail
       # cilium will cause kubespray to fail
-      # WORKING PROPERLY
-      # calico and contiv appears to deploy ok but observed some issues with rook and sonobuoy pods starting
+      # weave & flannel work
       networking_plugin: {{ networking_plugin }}
       service_subnet:  10.241.0.0/16
       pod_subnet: 10.251.0.0/16

--- a/doc/source/install/install.md
+++ b/doc/source/install/install.md
@@ -429,12 +429,6 @@ SNAPS-Kubernetes uses CNI plug-ins to orchestrate these networking solutions.
 
 #### Default Networks
 
-***Note: Weave is currently the only default network currently passing CNCF
-certification tests; however, Calico and Contiv do appear to deploy properly
-but the certification tests are still failing. Flannel will result in failed
-pods and cilium will cause the installer to fail within Kubespray***
-
-
 Parameters defined here specifies the default networking solution for the
 cluster.
 
@@ -447,7 +441,7 @@ solution.
 
 | Parameter | Required | Description |
 | --------- | -------- | ----------- |
-| networking_plugin | N | Network plugin to be used for default networking. Allowed values are weave, contiv, flannel, calico, cilium |
+| networking_plugin | N | Network plugin to be used for default networking. Allowed values are weave, contiv, flannel, calico, cilium (*** does not work***) |
 | service_subnet | N | Subnet to be used for Kubernetes service deployments (E.g. 10.241.0.0/18) |
 | pod_subnet | N | Subnet for pods networking (E.g. 10.241.64.0/18) |
 | network_name | N | Default network to be created by SNAPS-Kubernetes. Note: The name should not contain any Capital letter and “_”. |

--- a/snaps_k8s/common/utils/validate_cluster.py
+++ b/snaps_k8s/common/utils/validate_cluster.py
@@ -252,10 +252,10 @@ def validate_rook(k8s_conf):
 
     srvc_names = __get_service_names(core_client, 'rook-ceph')
     logger.debug('rook-ceph srvc_names - %s', srvc_names)
-    if 'rook-ceph-mgr' not in srvc_names:
-        raise ClusterDeploymentException(
-            'rook-ceph-mgr service not found in rook-ceph namespace')
-    # TODO/FIXME - This is not always available
+    # TODO/FIXME - These are not always available
+    # if 'rook-ceph-mgr' not in srvc_names:
+    #     raise ClusterDeploymentException(
+    #         'rook-ceph-mgr service not found in rook-ceph namespace')
     # if 'rook-ceph-mgr-dashboard' not in srvc_names:
     #     raise ClusterDeploymentException(
     #         'rook-ceph-mgr-dashboard service not found')
@@ -313,7 +313,7 @@ def __validate_cni_pods(k8s_conf):
             raise ClusterDeploymentException(
                 'contiv-netplugin service not found')
     elif net_plugin == 'calico':
-        if 'calico-net' not in pod_services:
+        if 'calico-kube-controllers' not in pod_services:
             raise ClusterDeploymentException('calico-net service not found')
     elif net_plugin == 'cilium':
         if 'cilium-net' not in pod_services:


### PR DESCRIPTION
Fixes #195

#### What does this PR do?
Changes the default network CIDR from 24 - 16 as kubespray/k8s will deploy successfully but the containers will not be fully operational
#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
run CI with the variable value 'networking_plugin' set to 'flannel'
#### Any background context you want to provide?
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
si
- Does the documentation need an update?
si
- Does this add new Python dependencies?
no
- Have you added unit or functional tests for this PR?
fixed the existing ones
- Does this patch update any configuration files?
no
