### PR TITLE
install add-apt-repository command before using it

### DIFF
--- a/snaps_k8s/playbooks/k8/kubectl_installation.yaml
+++ b/snaps_k8s/playbooks/k8/kubectl_installation.yaml
@@ -36,17 +36,22 @@
       url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
       state: present
 
-  # TODO/FIXME - Why isn't apt working when running with snaps-hyperbuild???
+  - name: Update repository cache and install "software-properties-common" package
+    become: true
+    become_user: root
+    become_method: sudo
+    apt:
+      name: software-properties-common
+      update_cache: yes
+
   - name: Add apt repo
     become: true
     become_user: root
     become_method: sudo
-    command: add-apt-repository 'deb http://apt.kubernetes.io/ kubernetes-xenial main'
-  - name: update apt cache
-    become: true
-    become_user: root
-    become_method: sudo
-    command: apt update
+    apt_repository:
+      repo: deb http://apt.kubernetes.io/ kubernetes-xenial main
+      state: present
+
   - name: install kubectl
     become: true
     become_user: root


### PR DESCRIPTION
#### What does this PR do?
Install add-apt-repository command before using it; otherwise the playbook using this command would fail.

#### Do you have any concerns with this PR?
No

#### How can the reviewer verify this PR?
Deploy snaps-kubernetes from scratch

#### Any background context you want to provide?
This did not fail in hyperbuild because software-properties-common package was already installed as a prerequisite for gpu driver.

#### Screenshots or logs (if appropriate)

#### Questions:
- Have you connected this PR to the issue it resolves?
#192 
- Does the documentation need an update?
No
- Does this add new Python dependencies?
No
- Have you added unit or functional tests for this PR?
No
- Does this patch update any configuration files?
No
