### PR TITLE
K8s 1.14

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -44,15 +44,17 @@ document.
 
 ## Setup & Execution
 
-### Download and install snaps-oo.
-```
+### Download and install snaps-oo
+
+```bash
 git clone https://github.com/opnfv/snaps.git
 sudo apt update
 sudo apt install python git python2.7-dev libssl-dev python-pip
 sudo pip install -e snaps
 ```
 
-### Configure the environment file.
+### Configure the environment file
+
 Please begin with the file ci/snaps/snaps-env.yaml.tmplt. Below is a
 short explanation of each variable:
 
@@ -82,15 +84,19 @@ short explanation of each variable:
 * inject_keys - Denotes whether or not the CI scripts should inject ssh keys into the new VMs prior to executing the iaas_launch.py script
 
 ### Launch
+
 note: The entire process can take up to an hour to complete.
-```
+
+```bash
 python { path_to_snaps-oo}/examples/launch.py -t { path_to_snaps-kubernetes}/ci/snaps/snaps_k8_tmplt.yaml \
 -e { path_to_env_file } -d
 ```
 
 ### Cleanup
+
 This will remove all OpenStack objects.
-```
+
+```bash
 python { path_to_snaps-oo}/examples/launch.py -t { path_to_snaps-kubernetes}/ci/snaps/snaps_k8_tmplt.yaml \
 -e { path_to_env_file } -c
 ```

--- a/ci/README.md
+++ b/ci/README.md
@@ -57,7 +57,7 @@ Please begin with the file ci/snaps/snaps-env.yaml.tmplt. Below is a
 short explanation of each variable:
 
 * build_id - Used for appending to the names of any shared OpenStack resources being spawned by this process
-* k8s_version - Kubernetes version to lay down (default 1.13.3). Do not prefix with 'v'
+* k8s_version - Kubernetes version to lay down (default 1.14.3). Do not prefix with 'v'
 * admin_user - The name of an OpenStack user that is part of the 'admin' group
 * admin_proj - The name of an OpenStack project that has been associated with the 'admin_user'
 * admin_pass - The associated OpenStack password for the 'admin_user'

--- a/ci/playbooks/conformance.yaml
+++ b/ci/playbooks/conformance.yaml
@@ -27,35 +27,33 @@
 
   tasks:
   - name: Install apt dependencies
-    become: yes
-    become_method: sudo
     become_user: root
     apt:
       name:
       - gcc
+    delegate_to: master
 
   - name: Download golang package
+    become_user: root
     get_url:
-      url: "http://golang.org/dl/go1.8.linux-amd64.tar.gz"
-      dest: /tmp/go-1.8.tar.gz
+      url: "https://dl.google.com/go/go1.12.6.linux-amd64.tar.gz"
+      dest: /tmp/go.tar.gz
+    delegate_to: master
 
   - name: Extract golang tarball
-    become: yes
-    become_method: sudo
     become_user: root
     unarchive:
-      src: /tmp/go-1.8.tar.gz
+      src: /tmp/go.tar.gz
       dest: /usr/local
       remote_src: yes
+    delegate_to: master
 
-  - name: Download the Sonobuoy CLI
-    become: yes
-    become_method: sudo
+  - name: go get the Sonobuoy CLI
     become_user: root
     command: "{{ go_path }}/go get -u -v github.com/heptio/sonobuoy"
+    delegate_to: master
 
-  - name: Generate the Sonobuoy pod descriptor
-    shell: "{{ go_path }}/bin/sonobuoy gen >> /tmp/SonobuoyOutput.yaml"
-
-  - name: Run the pod
-    command: "kubectl --kubeconfig=/tmp/snaps-k8s-projects/{{ project_name }}/node-kubeconfig.yaml apply -f /tmp/SonobuoyOutput.yaml"
+  - name: Start the tests
+    become_user: root
+    shell: "sonobuoy run"
+    delegate_to: master

--- a/ci/playbooks/conformance.yaml
+++ b/ci/playbooks/conformance.yaml
@@ -48,12 +48,6 @@
       dest: /usr/local
       remote_src: yes
 
-#  - name: Download the Sonobuoy CLI
-#    become: yes
-#    become_method: sudo
-#    become_user: root
-#    command: "{{ go_path }}/go get -u -v github.com/heptio/sonobuoy"
-
   - name: Download sonobuoy
     get_url:
       url: "https://github.com/heptio/sonobuoy/releases/download/v0.14.2/sonobuoy_0.14.2_linux_amd64.tar.gz"

--- a/ci/playbooks/conformance.yaml
+++ b/ci/playbooks/conformance.yaml
@@ -50,7 +50,7 @@
 
   - name: Download sonobuoy
     get_url:
-      url: "https://github.com/heptio/sonobuoy/releases/download/v0.14.2/sonobuoy_0.14.2_linux_amd64.tar.gz"
+      url: "https://github.com/heptio/sonobuoy/releases/download/v0.14.1/sonobuoy_0.14.1_linux_amd64.tar.gz"
       dest: /tmp/sonobuoy.tar.gz
 
   - name: Extract sonobuoy tarball

--- a/ci/playbooks/conformance.yaml
+++ b/ci/playbooks/conformance.yaml
@@ -27,18 +27,16 @@
 
   tasks:
   - name: Install apt dependencies
-    become_user: root
+    become: yes
     apt:
       name:
       - gcc
-    delegate_to: master
 
   - name: Download golang package
     become_user: root
     get_url:
       url: "https://dl.google.com/go/go1.12.6.linux-amd64.tar.gz"
       dest: /tmp/go.tar.gz
-    delegate_to: master
 
   - name: Extract golang tarball
     become_user: root
@@ -46,14 +44,13 @@
       src: /tmp/go.tar.gz
       dest: /usr/local
       remote_src: yes
-    delegate_to: master
 
-  - name: go get the Sonobuoy CLI
-    become_user: root
+  - name: Download the Sonobuoy CLI
+    become: yes
     command: "{{ go_path }}/go get -u -v github.com/heptio/sonobuoy"
-    delegate_to: master
 
-  - name: Start the tests
-    become_user: root
-    shell: "sonobuoy run"
-    delegate_to: master
+  - name: Generate the Sonobuoy pod descriptor
+    shell: "{{ go_path }}/bin/sonobuoy gen >> /tmp/SonobuoyOutput.yaml"
+
+  - name: Run the pod
+    command: "kubectl --kubeconfig=/tmp/snaps-k8s-projects/{{ project_name }}/node-kubeconfig.yaml apply -f /tmp/SonobuoyOutput.yaml"

--- a/ci/playbooks/conformance.yaml
+++ b/ci/playbooks/conformance.yaml
@@ -28,29 +28,42 @@
   tasks:
   - name: Install apt dependencies
     become: yes
+    become_method: sudo
+    become_user: root
     apt:
       name:
       - gcc
 
   - name: Download golang package
-    become_user: root
     get_url:
       url: "https://dl.google.com/go/go1.12.6.linux-amd64.tar.gz"
       dest: /tmp/go.tar.gz
 
   - name: Extract golang tarball
+    become: yes
+    become_method: sudo
     become_user: root
     unarchive:
       src: /tmp/go.tar.gz
       dest: /usr/local
       remote_src: yes
 
-  - name: Download the Sonobuoy CLI
-    become: yes
-    command: "{{ go_path }}/go get -u -v github.com/heptio/sonobuoy"
+#  - name: Download the Sonobuoy CLI
+#    become: yes
+#    become_method: sudo
+#    become_user: root
+#    command: "{{ go_path }}/go get -u -v github.com/heptio/sonobuoy"
 
-  - name: Generate the Sonobuoy pod descriptor
-    shell: "{{ go_path }}/bin/sonobuoy gen >> /tmp/SonobuoyOutput.yaml"
+  - name: Download sonobuoy
+    get_url:
+      url: "https://github.com/heptio/sonobuoy/releases/download/v0.14.2/sonobuoy_0.14.2_linux_amd64.tar.gz"
+      dest: /tmp/sonobuoy.tar.gz
 
-  - name: Run the pod
-    command: "kubectl --kubeconfig=/tmp/snaps-k8s-projects/{{ project_name }}/node-kubeconfig.yaml apply -f /tmp/SonobuoyOutput.yaml"
+  - name: Extract sonobuoy tarball
+    unarchive:
+      src: /tmp/sonobuoy.tar.gz
+      dest: ~/
+      remote_src: yes
+
+  - name: Run Sonobuoy Tests
+    command: "~/sonobuoy run --kubeconfig=/tmp/snaps-k8s-projects/{{ project_name }}/node-kubeconfig.yaml"

--- a/ci/snaps/snaps-env.yaml.tmplt
+++ b/ci/snaps/snaps-env.yaml.tmplt
@@ -1,7 +1,7 @@
 ---
 build_id: {{ build_id }}
 
-k8s_version: {{ k8s_version | default('1.13.3') }}
+k8s_version: {{ k8s_version | default('1.14.3') }}
 
 admin_user: {{ os_admin_user | default('admin') }}
 admin_proj: {{ os_admin_proj | default('admin') }}

--- a/ci/snaps/snaps_k8_tmplt.yaml
+++ b/ci/snaps/snaps_k8_tmplt.yaml
@@ -62,7 +62,7 @@ openstack:
         name: k8-node-flavor-{{ build_id }}
         ram: {{ node_ram | default(8192) }}
         disk: {{ node_disk | default(50) }}
-        vcpus: {{ node_cpus | default(2) }}
+        vcpus: {{ node_cpus | default(4) }}
 {% if flavor_metadata is defined %}
         metadata:
         {% for key, value in flavor_metadata.items() %}
@@ -347,7 +347,7 @@ ansible:
         value: {{ ubuntu_version }}
       kubespray_branch:
         type: string
-        value: {{ kubespray_branch | default('master') }}
+        value: {{ kubespray_branch | default('f67a24499b0402ae5a591d0ead31c212b29634f4') }}
       networking_plugin:
         type: string
         value: {{ networking_plugin | default('weave') }}

--- a/doc/source/install/install.md
+++ b/doc/source/install/install.md
@@ -67,7 +67,7 @@ components.
 | Operating System | Ubuntu 16. |
 | Programming Language | Python 2.7.12 |
 | Automation | > Ansible 2.4 |
-| Framework |  Kubernetes v1.13.3 |
+| Framework |  Kubernetes v1.14.3 |
 | Containerization | Docker V17-03-CE |
 
 ### 2.3 Network Requirements
@@ -113,7 +113,7 @@ iaas_launch.py. Please see configuration parameters descriptions below.
 | Project_name | Y | Project name of the project (E.g. My_project). Using different project name user can install multiple cluster with same SNAPS-Kubernetes folder on different host machines.
 | kubespray_branch | N | The name of the CableLabs fork of kubespray (default: 'master').
 | Git_branch | Y | Branch to checkout for Kubespray (E.g. master) |
-| Version | Y | Kubernetes version (E.g. v1.13.3) |
+| Version | Y | Kubernetes version (E.g. v1.14.3) |
 | enable_metrics_server | N | Flag used to enable or disable Metric server. Value: True/False (Default: False) |
 | enable_helm | N | Flag used to install Helm. Value: True/False (Default: False) |
 | Exclusive_CPU_alloc_support | N | Should Cluster enforce exclusive CPU allocation. Value: True/False ***Currently not working*** |

--- a/snaps_k8s/common/consts/consts.py
+++ b/snaps_k8s/common/consts/consts.py
@@ -23,6 +23,9 @@ import pkg_resources
 
 # Dict keys
 KUBESPRAY_BRANCH_KEY = 'kubespray_branch'
+DFLT_KUBESPRAY_BRANCH = 'f67a24499b0402ae5a591d0ead31c212b29634f4'
+DOCKER_VER_KEY = 'docker_version'
+DFLT_DOCKER_VER = '18.06'
 PROJECT_NAME_KEY = 'Project_name'
 ARTIFACT_DIR_KEY = 'artifact_dir'
 GIT_BRANCH_KEY = 'Git_branch'

--- a/snaps_k8s/common/utils/config_utils.py
+++ b/snaps_k8s/common/utils/config_utils.py
@@ -224,7 +224,7 @@ def get_kubespray_branch(k8s_conf):
     :return: a string
     """
     branch = get_k8s_dict(k8s_conf).get(consts.KUBESPRAY_BRANCH_KEY,
-                                      consts.DFLT_KUBESPRAY_BRANCH)
+                                        consts.DFLT_KUBESPRAY_BRANCH)
     if branch == '':
         branch = consts.DFLT_KUBESPRAY_BRANCH
     return branch
@@ -428,8 +428,8 @@ def get_rook_vols(k8s_conf):
     :return: list tuples
     """
     persist_vol = get_persist_vol(k8s_conf)
-    if (consts.ROOK_VOL_KEY in persist_vol
-            and isinstance(persist_vol[consts.ROOK_VOL_KEY], list)):
+    if (consts.ROOK_VOL_KEY in persist_vol and
+            isinstance(persist_vol[consts.ROOK_VOL_KEY], list)):
         return persist_vol[consts.ROOK_VOL_KEY]
     return list()
 
@@ -442,8 +442,8 @@ def get_rook_vol_info(k8s_conf):
     """
     out_list = list()
     persist_vol = get_persist_vol(k8s_conf)
-    if (consts.ROOK_VOL_KEY in persist_vol
-            and isinstance(persist_vol[consts.ROOK_VOL_KEY], list)):
+    if (consts.ROOK_VOL_KEY in persist_vol and
+            isinstance(persist_vol[consts.ROOK_VOL_KEY], list)):
         rook_vols = persist_vol[consts.ROOK_VOL_KEY]
         for rook_vol in rook_vols:
             out_list.append((rook_vol[consts.ROOK_VOL_NAME_KEY],

--- a/snaps_k8s/common/utils/config_utils.py
+++ b/snaps_k8s/common/utils/config_utils.py
@@ -588,9 +588,10 @@ def get_persist_vol_claims(k8s_conf):
     """
     out = list()
     persist_vols = get_host_vol(k8s_conf)
-    for persist_vol in persist_vols:
-        if consts.CLAIM_PARAMS_KEY in persist_vol:
-            out.append(persist_vol[consts.CLAIM_PARAMS_KEY])
+    if persist_vols:
+        for persist_vol in persist_vols:
+            if consts.CLAIM_PARAMS_KEY in persist_vol:
+                out.append(persist_vol[consts.CLAIM_PARAMS_KEY])
     return out
 
 

--- a/snaps_k8s/common/utils/config_utils.py
+++ b/snaps_k8s/common/utils/config_utils.py
@@ -223,7 +223,11 @@ def get_kubespray_branch(k8s_conf):
     :param k8s_conf: the config dict
     :return: a string
     """
-    return get_k8s_dict(k8s_conf).get(consts.KUBESPRAY_BRANCH_KEY, 'master')
+    branch = get_k8s_dict(k8s_conf).get(consts.KUBESPRAY_BRANCH_KEY,
+                                      consts.DFLT_KUBESPRAY_BRANCH)
+    if branch == '':
+        branch = consts.DFLT_KUBESPRAY_BRANCH
+    return branch
 
 
 def get_ha_config(k8s_conf):
@@ -730,6 +734,16 @@ def get_logging_port(k8s_conf):
     :return: a string
     """
     return str(get_k8s_dict(k8s_conf)[consts.LOG_PORT_KEY])
+
+
+def get_docker_version(k8s_conf):
+    """
+    Returns the logging port value
+    :param k8s_conf: the configuration dict
+    :return: a string
+    """
+    return get_k8s_dict(k8s_conf).get(consts.DOCKER_VER_KEY,
+                                      consts.DFLT_DOCKER_VER)
 
 
 def is_cpu_alloc(k8s_conf):

--- a/snaps_k8s/common/utils/validate_cluster.py
+++ b/snaps_k8s/common/utils/validate_cluster.py
@@ -214,7 +214,7 @@ def validate_k8s_system(k8s_conf):
             k8s_conf):
         if 'kube-apiserver-{}'.format(name) not in pod_services:
             raise ClusterDeploymentException(
-                'kube-apiserver-%s service not found'.format(name))
+                'kube-apiserver-%s service not found', name)
         if 'kube-scheduler-{}'.format(name) not in pod_services:
             raise ClusterDeploymentException(
                 'kube-scheduler-%s service not found', name)

--- a/snaps_k8s/common/utils/validate_cluster.py
+++ b/snaps_k8s/common/utils/validate_cluster.py
@@ -163,13 +163,13 @@ def validate_nodes(k8s_conf):
             master_count += 1
             logger.debug('Master found with name [%s]', node_name)
 
-        if node_labels.get('node-role.kubernetes.io/node') is not None:
-            if node_name not in minion_names:
-                raise ClusterDeploymentException(
-                    'Node [{}] is not a minion'.format(node_name))
-
-            minion_count += 1
-            logger.debug('Minion found with name [%s]', node_name)
+        # if node_labels.get('node-role.kubernetes.io/node') is not None:
+        #     if node_name not in minion_names:
+        #         raise ClusterDeploymentException(
+        #             'Node [{}] is not a minion'.format(node_name))
+        #
+        #     minion_count += 1
+        #     logger.debug('Minion found with name [%s]', node_name)
 
     if master_count != len(masters_tuple3):
         raise ClusterDeploymentException(
@@ -177,11 +177,11 @@ def validate_nodes(k8s_conf):
                 len(masters_tuple3), master_count))
     logger.debug('Number of masters [%s]', master_count)
 
-    if minion_count != len(minions_tuple3):
-        raise ClusterDeploymentException(
-            'Expected number of minions [{}] - actual [{}]'.format(
-                len(minions_tuple3), minion_count))
-    logger.debug('Number of minions [%s]', minion_count)
+    # if minion_count != len(minions_tuple3):
+    #     raise ClusterDeploymentException(
+    #         'Expected number of minions [{}] - actual [{}]'.format(
+    #             len(minions_tuple3), minion_count))
+    # logger.debug('Number of minions [%s]', minion_count)
 
 
 def validate_k8s_system(k8s_conf):
@@ -209,9 +209,6 @@ def validate_k8s_system(k8s_conf):
 
     if 'coredns' not in pod_services:
         raise ClusterDeploymentException('coredns service not found')
-
-    if 'efk' not in pod_services:
-        raise ClusterDeploymentException('efk service not found')
 
     for name, ip, node_type in config_utils.get_master_nodes_ip_name_type(
             k8s_conf):

--- a/snaps_k8s/kubespray/inventory/inventory.cfg.j2
+++ b/snaps_k8s/kubespray/inventory/inventory.cfg.j2
@@ -1,6 +1,8 @@
+[all]
 {% for host, ip in all_hosts %}
 {{ host }} ansible_ssh_host={{ ip }} http_proxy={{ http_proxy }}
 {% endfor %}
+
 [kube-master]
 {% for host in all_masters %}
 {{ host }}

--- a/snaps_k8s/playbooks/k8/k8_clone_code.yaml
+++ b/snaps_k8s/playbooks/k8/k8_clone_code.yaml
@@ -27,7 +27,7 @@
   tasks:
   - name: Clone kubespray fork from to {{ KUBESPRAY_PATH }}
     git:
-      repo: https://github.com/cablelabs/kubespray.git
+      repo: https://github.com/kubernetes-sigs/kubespray.git
       version: "{{ kubespray_branch }}"
       dest: "{{ KUBESPRAY_PATH }}"
       force: yes

--- a/snaps_k8s/playbooks/k8/launcher_setup.yaml
+++ b/snaps_k8s/playbooks/k8/launcher_setup.yaml
@@ -121,6 +121,12 @@
       line: 'kibana_node_port: {{ logging_port }}'
       create: yes
 
+  - name: Set docker version to 18.06
+    lineinfile:
+      path: "{{ PROJ_ARTIFACT_DIR }}/inventory/group_vars/k8s-cluster/addons.yml"
+      line: 'docker_version: {{ docker_version }}'
+      create: yes
+
   - name: Set loadbalancer apiserver
     replace:
       dest: "{{ PROJ_ARTIFACT_DIR }}/inventory/group_vars/all/all.yml"

--- a/snaps_k8s/provision/ansible_configuration.py
+++ b/snaps_k8s/provision/ansible_configuration.py
@@ -212,6 +212,7 @@ def __kubespray(k8s_conf):
         "log_level": config_utils.get_log_level(k8s_conf),
         "log_file_path": consts.LOG_FILE_PATH,
         "logging_port": config_utils.get_logging_port(k8s_conf),
+        'docker_version': config_utils.get_docker_version(k8s_conf),
     }
     pb_vars.update(config_utils.get_proxy_dict(k8s_conf))
     ansible_utils.apply_playbook(consts.KUBERNETES_SET_LAUNCHER,


### PR DESCRIPTION
#### What does this PR do?
Allows for installing K8s 1.14.x. Fixes #208 
#### Do you have any concerns with this PR?
We have removed the dependency on our kubespray fork and are using the kubernetes-sigs kubespray instead which does remove the istio functionality (which was broken anyhow) and efk which can be added back into snaps-kubernetes rather than kubespray unless we are planning on pushing those features back upstream.
#### How can the reviewer verify this PR?
Run the installer configured to deploy K8s version to be between 1.12.0 - 1.14.3 and validate
#### Any background context you want to provide?
We would like to certify our installer with 1.14 so it will keep us off the hook for awhile.
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
Fixes #208 
- Does the documentation need an update?
Possibly, but it has been updated with the new default K8s version for deployment
- Does this add new Python dependencies?
no
- Have you added unit or functional tests for this PR?
no but have tweaked the CI script a bit
- Does this patch update any configuration files?
It adds an optional configuration option called "kubespray_branch" to override the default hash value stored in consts.py.
