### PR TITLE
Fixes #234. Need to create the remote directory before using it.

### DIFF
--- a/snaps_k8s/playbooks/k8/kubectl_installation.yaml
+++ b/snaps_k8s/playbooks/k8/kubectl_installation.yaml
@@ -65,6 +65,9 @@
       dest: "{{ PROJ_ARTIFACT_DIR }}/node-kubeconfig.yaml"
       backup: yes
 
+  - name: create the $HOME directory on {{ ip }} if it does not exist
+    command: "ssh -o StrictHostKeyChecking=no {{ node_user }}@{{ ip }} 'sudo mkdir -p $HOME'"
+
   - name: copy {{ KUBERNETES_PATH }}/ssl folder on {{ ip }} to $HOME/ssl
     command: "ssh -o StrictHostKeyChecking=no {{ node_user }}@{{ ip }} 'sudo cp -r {{ KUBERNETES_PATH }}/ssl/ $HOME/'"
   - name: change ownership of $HOME/ssl to {{ node_user }}


### PR DESCRIPTION
#### What does this PR do?
Create a remote directory before using it.

#### Do you have any concerns with this PR?
No

#### How can the reviewer verify this PR?
Deploy K8s on a system that is not ubuntu.

#### Any background context you want to provide?
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
#234 
- Does the documentation need an update?
No
- Does this add new Python dependencies?
No
- Have you added unit or functional tests for this PR?
No
- Does this patch update any configuration files?
No
