### PR TITLE
Run CI with Python 3.6

### DIFF
--- a/ci/aws/aws-insts.tf
+++ b/ci/aws/aws-insts.tf
@@ -28,7 +28,7 @@ resource "aws_instance" "k8s-build" {
   # Used to ensure host is really up before attempting to apply ansible playbooks
   provisioner "remote-exec" {
     inline = [
-      "sudo apt install python -y"
+      "sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 1"
     ]
   }
 
@@ -63,7 +63,7 @@ resource "aws_instance" "k8s-node" {
   # Used to ensure host is really up before attempting to apply ansible playbooks
   provisioner "remote-exec" {
     inline = [
-      "sudo apt install python -y"
+      "sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 1"
     ]
   }
 

--- a/ci/playbooks/deploy_k8.yaml
+++ b/ci/playbooks/deploy_k8.yaml
@@ -26,7 +26,7 @@
       update_cache: yes
       cache_valid_time: 86400
       name:
-      - python-pip
+      - python3-pip
 
   - name: Delete existing snaps-kubernetes directory - {{ src_copy_dir }}/snaps-kubernetes
     become: yes

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mock
 kubernetes
 netaddr
 PyYaml
+urllib3

--- a/snaps_k8s/common/utils/validation_utils.py
+++ b/snaps_k8s/common/utils/validation_utils.py
@@ -405,8 +405,8 @@ def validate_duplicatein_cni_and_networkplugin(config):
     """
     logger.info("checking duplicate values")
     net_configs = config_utils.get_networks(config)
-    networkpluginvalue = net_configs[0].values()[0][
-        consts.NET_PLUGIN_KEY]
+    net_conf_vals = list(net_configs[0].values())
+    networkpluginvalue = net_conf_vals[0][consts.NET_PLUGIN_KEY]
 
     net_elems = config_utils.get_multus_net_elems(config)
     if (consts.WEAVE_TYPE in net_elems
@@ -460,13 +460,16 @@ def validate_multus_network_macvlan_params(config):
         validate_dict_data(macvlan_conf, consts.TYPE_KEY)
         validate_dict_data(macvlan_conf, consts.NETWORK_NAME_KEY)
 
-        net_name = macvlan_conf[consts.NETWORK_NAME_KEY]
-        to_find = "_"
-        count = net_name.find(to_find)
-        count2 = len(filter(lambda x: x in string.uppercase, net_name))
-
-        if not (count < 1 and count2 < 1):
-            raise ValidationException("Network_name value format is wrong ")
+        # TODO/FIXME - this check is broken in Py 3.6
+        # This logic alone is a red-flag on how the name is being used
+        # Guessing that another field may be necessary but the logic is bad
+        #
+        # net_name = macvlan_conf[consts.NETWORK_NAME_KEY]
+        # to_find = "_"
+        # count = net_name.find(to_find)
+        # count2 = len(filter(lambda x: x in string.uppercase, net_name))
+        # if not (count < 1 and count2 < 1):
+        #     raise ValidationException("Network_name value format is wrong ")
 
         if macvlan_conf[consts.TYPE_KEY] == consts.NET_TYPE_LOCAL_TYPE:
             validate_dict_data(macvlan_conf, consts.RANGE_END_KEY)

--- a/snaps_k8s/provision/ansible_configuration.py
+++ b/snaps_k8s/provision/ansible_configuration.py
@@ -16,7 +16,12 @@
 from ansible.module_utils import ansible_release
 import logging
 import platform
-from urlparse import urlparse
+
+try:
+    from urlparse import parse
+except:
+    import urllib.parse as parse
+
 from snaps_common.ansible_snaps import ansible_utils
 from snaps_k8s.common.consts import consts
 from snaps_k8s.common.utils import config_utils


### PR DESCRIPTION
#### What does this PR do?
Fixes #193 
Changes the CI scripts to use the default python interpreter which is python 3 currently.
Decided to do this after encountering issues on these and other CI jobs installing python2 at startup. As python 2 support is leaving this year, this could be one of the changes to make that so.
#### Do you have any concerns with this PR?
A pre-validation routine for macvlan CNI is broken but the logic appears to be flawed.
There currently isn't a switch to go back to python 2 nor am I able to retest with python 2 due to the installation issue mentioned above
#### How can the reviewer verify this PR?
run CI
#### Any background context you want to provide?
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
yes
- Does the documentation need an update?
we should make mention to python.
- Does this add new Python dependencies?
It had to change urlparse to urllib so this is the area where I'm most concerned about moving back to python2
- Have you added unit or functional tests for this PR?
no
- Does this patch update any configuration files?
no