### PR TITLE
Fix CI scripts

### DIFF
--- a/ci/aws/aws-insts.tf
+++ b/ci/aws/aws-insts.tf
@@ -28,7 +28,9 @@ resource "aws_instance" "k8s-build" {
   # Used to ensure host is really up before attempting to apply ansible playbooks
   provisioner "remote-exec" {
     inline = [
-      "sudo apt install python -y"
+      "sudo apt update",
+      "sudo apt install python2.7 -y",
+      "sudo ln /usr/bin/python2.7 /usr/bin/python"
     ]
   }
 
@@ -63,7 +65,9 @@ resource "aws_instance" "k8s-node" {
   # Used to ensure host is really up before attempting to apply ansible playbooks
   provisioner "remote-exec" {
     inline = [
-      "sudo apt install python -y"
+      "sudo apt update",
+      "sudo apt install python2.7 -y",
+      "sudo ln /usr/bin/python2.7 /usr/bin/python"
     ]
   }
 


### PR DESCRIPTION
#### What does this PR do?
Fixes #248 
Changed the way installing python 2.7 as the previous method is now failing apparently due to changes to apt repositories for python 2
#### Do you have any concerns with this PR?
not now, but we will need to migrate all of our stuff to Python 3.6+
#### How can the reviewer verify this PR?
run ci
#### Any background context you want to provide?
Observed the issue running a different CI script with same method of installing python
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
yes
- Does the documentation need an update?
no
- Does this add new Python dependencies?
no
- Have you added unit or functional tests for this PR?
no
- Does this patch update any configuration files?
no